### PR TITLE
rlang update

### DIFF
--- a/R/as_mapper.R
+++ b/R/as_mapper.R
@@ -133,5 +133,5 @@ extractor <- function(i, default) {
 
 #' @export
 as_mapper.default <- function(.f, ...) {
-  rlang::as_function(.f)
+  rlang::as_closure(.f)
 }

--- a/R/list-modify.R
+++ b/R/list-modify.R
@@ -71,7 +71,7 @@ list_modify <- function(x, y) {
 #' @export
 #' @rdname  list_modify
 list_update <- function(`_x`, ...) {
-  y <- modify_if(list(...), is_quosure, eval_tidy, `_x`)
+  y <- modify_if(list(...), is_symbolic, eval_tidy, `_x`)
   list_modify(`_x`, y)
 }
 

--- a/R/list-modify.R
+++ b/R/list-modify.R
@@ -29,9 +29,9 @@
 #' str(list_update(x, z = list(a = 1:5)))
 #' str(list_update(x, z = NULL))
 #'
-#' # In list_update() you can also use formulas to compute new values
-#' list_update(x, z1 = ~ z[1])
-#' list_update(x, z = ~ x + y)
+#' # In list_update() you can also use quosures to compute new values
+#' list_update(x, z1 = rlang::quo(z[1]))
+#' list_update(x, z = rlang::quo(x + y))
 list_modify <- function(x, y) {
   stopifnot(is.list(x), is.list(y))
 
@@ -71,11 +71,7 @@ list_modify <- function(x, y) {
 #' @export
 #' @rdname  list_modify
 list_update <- function(`_x`, ...) {
-  y <- list(...)
-
-  needs_eval <- map_lgl(y, is_quosure)
-  y[needs_eval] <- rlang::eval_tidy(y[needs_eval], `_x`)
-
+  y <- modify_if(list(...), is_quosure, eval_tidy, `_x`)
   list_modify(`_x`, y)
 }
 

--- a/R/list-modify.R
+++ b/R/list-modify.R
@@ -71,7 +71,8 @@ list_modify <- function(x, y) {
 #' @export
 #' @rdname  list_modify
 list_update <- function(`_x`, ...) {
-  y <- modify_if(list(...), is_symbolic, eval_tidy, `_x`)
+  y <- dots_list(...)
+  y <- modify_if(y, is_symbolic, eval_tidy, data = `_x`)
   list_modify(`_x`, y)
 }
 

--- a/man/list_modify.Rd
+++ b/man/list_modify.Rd
@@ -43,7 +43,7 @@ str(list_update(x, z = 5))
 str(list_update(x, z = list(a = 1:5)))
 str(list_update(x, z = NULL))
 
-# In list_update() you can also use formulas to compute new values
-list_update(x, z1 = ~ z[1])
-list_update(x, z = ~ x + y)
+# In list_update() you can also use quosures to compute new values
+list_update(x, z1 = rlang::quo(z[1]))
+list_update(x, z = rlang::quo(x + y))
 }

--- a/tests/testthat/test-as-mapper.R
+++ b/tests/testthat/test-as-mapper.R
@@ -48,8 +48,6 @@ test_that("Additional arguments are ignored", {
 # primitive functions --------------------------------------------------
 
 test_that("primitive functions are wrapped", {
-  skip("until we use rlang::as_closure()")
-  # See https://github.com/hadley/rlang/issues/75
-  expect_identical(as_mapper(`-`)(e2 = 10, e1 = 5), -5)
+  expect_identical(as_mapper(`-`)(.y = 10, .x = 5), -5)
   expect_identical(as_mapper(`c`)(1, 3, 5), c(1, 3, 5))
 })

--- a/tests/testthat/test-as-mapper.R
+++ b/tests/testthat/test-as-mapper.R
@@ -51,3 +51,8 @@ test_that("primitive functions are wrapped", {
   expect_identical(as_mapper(`-`)(.y = 10, .x = 5), -5)
   expect_identical(as_mapper(`c`)(1, 3, 5), c(1, 3, 5))
 })
+
+test_that("syntactic primitives are wrapped", {
+  expect_identical(as_mapper(`[[`)(mtcars, "cyl"), mtcars$cyl)
+  expect_identical(as_mapper(`$`)(mtcars, cyl), mtcars$cyl)
+})

--- a/tests/testthat/test-list-modify-update.R
+++ b/tests/testthat/test-list-modify-update.R
@@ -8,6 +8,10 @@ test_that("quosures are evaluated", {
   expect_equal(list_update(list(x = 1), y = quo(x + 1)), list(x = 1, y = 2))
 })
 
+test_that("any symbolic argument is evaluated", {
+  expect_equal(list_update(list(x = 1), y = quote(x + 1)), list(x = 1, y = 2))
+})
+
 
 # list_modify -------------------------------------------------------------
 

--- a/tests/testthat/test-list-modify-update.R
+++ b/tests/testthat/test-list-modify-update.R
@@ -5,7 +5,7 @@ test_that("can modify element called x", {
 })
 
 test_that("quosures are evaluated", {
-  expect_equal(list_update(list(x = 1), y = ~ x + 1), list(x = 1, y = 2))
+  expect_equal(list_update(list(x = 1), y = quo(x + 1)), list(x = 1, y = 2))
 })
 
 

--- a/tests/testthat/test-negate.R
+++ b/tests/testthat/test-negate.R
@@ -5,8 +5,6 @@ test_that("negate works with both functions and vectors", {
   expect_equal(negate(true)(), FALSE)
   expect_equal(negate("x")(list(x = TRUE)), FALSE)
 
-  skip("until we use rlang::as_closure()")
-  # See https://github.com/hadley/rlang/issues/75
   expect_equal(negate(is.null)(TRUE), TRUE)
   expect_equal(negate(is.null)(NULL), FALSE)
 })


### PR DESCRIPTION
- Use quosures in `list_modify()`. And evaluate any symbolic arguments and take dots with explicit splicing.

- Use `as_quosure()` in `as_mapper()` default method.

@hadley would it be better to add an option to `eval_tidy()` to treat bare formulas as quosures? I thought it's probably better to be consistent.