### PR TITLE
Fix typo in README.Rmd and generated files

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -38,7 +38,7 @@ devtools::install_github("tidyverse/purrr")
 
 ## Usage
 
-The following example uses purrr to solve a fairly realistic problem: split a data frame into pieces, fit a model to each piece, compute the summarse, then extract the R^2^.
+The following example uses purrr to solve a fairly realistic problem: split a data frame into pieces, fit a model to each piece, compute the summary, then extract the R^2^.
 
 ```{r}
 library(purrr)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ devtools::install_github("tidyverse/purrr")
 Usage
 -----
 
-The following example uses purrr to solve a fairly realistic problem: split a data frame into pieces, fit a model to each piece, compute the summarse, then extract the R<sup>2</sup>.
+The following example uses purrr to solve a fairly realistic problem: split a data frame into pieces, fit a model to each piece, compute the summary, then extract the R<sup>2</sup>.
 
 ``` r
 library(purrr)

--- a/docs/index.html
+++ b/docs/index.html
@@ -88,7 +88,7 @@ devtools::<span class="kw">install_github</span>(<span class="st">"tidyverse/pur
 <div id="usage" class="section level2">
 <h2 class="hasAnchor">
 <a href="#usage" class="anchor"></a>Usage</h2>
-<p>The following example uses purrr to solve a fairly realistic problem: split a data frame into pieces, fit a model to each piece, compute the summarse, then extract the R<sup>2</sup>.</p>
+<p>The following example uses purrr to solve a fairly realistic problem: split a data frame into pieces, fit a model to each piece, compute the summary, then extract the R<sup>2</sup>.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">library</span>(purrr)
 
 mtcars %&gt;%


### PR DESCRIPTION
Fixed typo in README.md and index.html as well in case it is a while before these are regenerated from README.Rmd