### PR TITLE
use map_dfr() instead of map_df() in documentations

### DIFF
--- a/R/map.R
+++ b/R/map.R
@@ -93,11 +93,11 @@
 #' mtcars %>% map_dbl(sum)
 #'
 #' # If each element of the output is a data frame, use
-#' # map_df to row-bind them together:
+#' # map_dfr to row-bind them together:
 #' mtcars %>%
 #'   split(.$cyl) %>%
 #'   map(~ lm(mpg ~ wt, data = .x)) %>%
-#'   map_df(~ as.data.frame(t(as.matrix(coef(.)))))
+#'   map_dfr(~ as.data.frame(t(as.matrix(coef(.)))))
 #' # (if you also want to preserve the variable names see
 #' # the broom package)
 map <- function(.x, .f, ...) {

--- a/R/reduce.R
+++ b/R/reduce.R
@@ -165,7 +165,7 @@ seq_len2 <- function(start, end) {
 #' rerun(5, rnorm(100)) %>%
 #'   set_names(paste0("sim", 1:5)) %>%
 #'   map(~ accumulate(., ~ .05 + .x + .y)) %>%
-#'   map_df(~ data_frame(value = .x, step = 1:100), .id = "simulation") %>%
+#'   map_dfr(~ data_frame(value = .x, step = 1:100), .id = "simulation") %>%
 #'   ggplot(aes(x = step, y = value)) +
 #'     geom_line(aes(color = simulation)) +
 #'     ggtitle("Simulations of a random walk with drift")

--- a/man/accumulate.Rd
+++ b/man/accumulate.Rd
@@ -54,7 +54,7 @@ library(ggplot2)
 rerun(5, rnorm(100)) \%>\%
   set_names(paste0("sim", 1:5)) \%>\%
   map(~ accumulate(., ~ .05 + .x + .y)) \%>\%
-  map_df(~ data_frame(value = .x, step = 1:100), .id = "simulation") \%>\%
+  map_dfr(~ data_frame(value = .x, step = 1:100), .id = "simulation") \%>\%
   ggplot(aes(x = step, y = value)) +
     geom_line(aes(color = simulation)) +
     ggtitle("Simulations of a random walk with drift")

--- a/man/map.Rd
+++ b/man/map.Rd
@@ -152,11 +152,11 @@ mtcars \%>\% map(sum)
 mtcars \%>\% map_dbl(sum)
 
 # If each element of the output is a data frame, use
-# map_df to row-bind them together:
+# map_dfr to row-bind them together:
 mtcars \%>\%
   split(.$cyl) \%>\%
   map(~ lm(mpg ~ wt, data = .x)) \%>\%
-  map_df(~ as.data.frame(t(as.matrix(coef(.)))))
+  map_dfr(~ as.data.frame(t(as.matrix(coef(.)))))
 # (if you also want to preserve the variable names see
 # the broom package)
 }


### PR DESCRIPTION
As NEWS says:

> The data frame suffix `_df` has been (soft) deprecated in favour of `_dfr` to more clearly indicate that it's a row-bind.