### PR TITLE
Fix mapping to data frames with functions returning vectors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # purrr 0.2.3.9000
 
+* `map_dfr()` and `map_dfc()` now handle functions returning vectors
+  correctly (#179).
+
 
 # purrr 0.2.3
 

--- a/R/map.R
+++ b/R/map.R
@@ -167,7 +167,7 @@ map_dfr <- function(.x, .f, ..., .id = NULL) {
 
   .f <- as_mapper(.f, ...)
   res <- map(.x, .f, ...)
-  dplyr::bind_rows(res, .id = .id)
+  dplyr::bind_rows(!!! res, .id = .id)
 }
 
 #' @rdname map
@@ -184,7 +184,7 @@ map_dfc <- function(.x, .f, ...) {
 
   .f <- as_mapper(.f, ...)
   res <- map(.x, .f, ...)
-  dplyr::bind_cols(res)
+  dplyr::bind_cols(!!! res)
 }
 
 #' @export

--- a/tests/testthat/test-map.R
+++ b/tests/testthat/test-map.R
@@ -53,15 +53,6 @@ test_that("map forces arguments in same way as base R", {
   expect_equal(f_map[[2]](0), f_base[[2]](0))
 })
 
-test_that("row and column binding work", {
-  mtcar_mod <- mtcars %>%
-    split(.$cyl) %>%
-    map(~ lm(mpg ~ wt, data = .x))
-  f_coef <- function(x) as.data.frame(t(as.matrix(coef(x))))
-  expect_length(mtcar_mod %>% map_dfr(f_coef), 2)
-  expect_length(mtcar_mod %>% map_dfc(f_coef), 6)
-})
-
 test_that("walk is used for side-effects", {
   expect_output(walk(1:3, str))
 })
@@ -70,4 +61,10 @@ test_that("map_if() and map_at() always return a list", {
   df <- tibble::tibble(x = 1, y = "a")
   expect_identical(map_if(df, is.character, ~"out"), list(x = 1, y = "out"))
   expect_identical(map_at(df, 1, ~"out"), list(x = "out", y = "a"))
+})
+
+test_that("row and column binding work", {
+  tbl <- tibble::tibble(x = 1, y = 2)
+  expect_identical(map_dfr(1:2, ~tbl), dplyr::bind_rows(tbl, tbl))
+  expect_identical(map_dfc(1:2, ~tbl), dplyr::bind_cols(tbl, tbl))
 })

--- a/tests/testthat/test-map.R
+++ b/tests/testthat/test-map.R
@@ -63,8 +63,23 @@ test_that("map_if() and map_at() always return a list", {
   expect_identical(map_at(df, 1, ~"out"), list(x = "out", y = "a"))
 })
 
-test_that("row and column binding work", {
+test_that("map_dfr() and map_dfc() handle data frames", {
   tbl <- tibble::tibble(x = 1, y = 2)
   expect_identical(map_dfr(1:2, ~tbl), dplyr::bind_rows(tbl, tbl))
   expect_identical(map_dfc(1:2, ~tbl), dplyr::bind_cols(tbl, tbl))
+})
+
+test_that("map_dfr() and map_dfc() handle dataframeable lists", {
+  tbl <- tibble::tibble(x = 1, y = 2)
+  list <- list(x = 1, y = 2)
+  expect_identical(map_dfr(1:2, ~list), dplyr::bind_rows(tbl, tbl))
+  expect_identical(map_dfc(1:2, ~list), dplyr::bind_cols(tbl, tbl))
+})
+
+test_that("map_dfr() and map_dfc() handle named vectors", {
+  row <- c(x = 1, y = 2)
+  expect_identical(map_dfr(1:2, ~row), tibble::tibble(x = c(1, 1), y = c(2, 2)))
+
+  col <- c(1, 2)
+  expect_identical(map_dfc(c(w = 0, z = 0), ~col), tibble::tibble(w = col, z = col))
 })


### PR DESCRIPTION
Since we had to preserve original semantics for dataframeable lists in `bind_rows()` and `bind_cols()`, the lists of vectors need to be explicitly spliced.