### PR TITLE
Fix typo in as_mapper.R documentation

### DIFF
--- a/R/as_mapper.R
+++ b/R/as_mapper.R
@@ -21,7 +21,7 @@
 #'   If __character vector__, __numeric vector__, or __list__, it
 #'   is converted to an extractor function. Character vectors index by name
 #'   and numeric vectors index by position; use a list to index by position
-#'   and name at different levels. Within a list, wrap strings in `get_attr()`
+#'   and name at different levels. Within a list, wrap strings in [get-attr()]
 #'   to extract named attributes. If a component is not present, the value of
 #'   `.default` will be returned.
 #' @param .default,.null Optional additional argument for extractor functions

--- a/man/as_mapper.Rd
+++ b/man/as_mapper.Rd
@@ -34,7 +34,7 @@ This syntax allows you to create very compact anonymous functions.
 If \strong{character vector}, \strong{numeric vector}, or \strong{list}, it
 is converted to an extractor function. Character vectors index by name
 and numeric vectors index by position; use a list to index by position
-and name at different levels. Within a list, wrap strings in \code{get_attr()}
+and name at different levels. Within a list, wrap strings in \code{\link[=get-attr]{get-attr()}}
 to extract named attributes. If a component is not present, the value of
 \code{.default} will be returned.}
 

--- a/man/detect.Rd
+++ b/man/detect.Rd
@@ -29,7 +29,7 @@ This syntax allows you to create very compact anonymous functions.
 If \strong{character vector}, \strong{numeric vector}, or \strong{list}, it
 is converted to an extractor function. Character vectors index by name
 and numeric vectors index by position; use a list to index by position
-and name at different levels. Within a list, wrap strings in \code{get_attr()}
+and name at different levels. Within a list, wrap strings in \code{\link[=get-attr]{get-attr()}}
 to extract named attributes. If a component is not present, the value of
 \code{.default} will be returned.}
 

--- a/man/imap.Rd
+++ b/man/imap.Rd
@@ -47,7 +47,7 @@ This syntax allows you to create very compact anonymous functions.
 If \strong{character vector}, \strong{numeric vector}, or \strong{list}, it
 is converted to an extractor function. Character vectors index by name
 and numeric vectors index by position; use a list to index by position
-and name at different levels. Within a list, wrap strings in \code{get_attr()}
+and name at different levels. Within a list, wrap strings in \code{\link[=get-attr]{get-attr()}}
 to extract named attributes. If a component is not present, the value of
 \code{.default} will be returned.}
 

--- a/man/map.Rd
+++ b/man/map.Rd
@@ -54,7 +54,7 @@ This syntax allows you to create very compact anonymous functions.
 If \strong{character vector}, \strong{numeric vector}, or \strong{list}, it
 is converted to an extractor function. Character vectors index by name
 and numeric vectors index by position; use a list to index by position
-and name at different levels. Within a list, wrap strings in \code{get_attr()}
+and name at different levels. Within a list, wrap strings in \code{\link[=get-attr]{get-attr()}}
 to extract named attributes. If a component is not present, the value of
 \code{.default} will be returned.}
 

--- a/man/map2.Rd
+++ b/man/map2.Rd
@@ -74,7 +74,7 @@ This syntax allows you to create very compact anonymous functions.
 If \strong{character vector}, \strong{numeric vector}, or \strong{list}, it
 is converted to an extractor function. Character vectors index by name
 and numeric vectors index by position; use a list to index by position
-and name at different levels. Within a list, wrap strings in \code{get_attr()}
+and name at different levels. Within a list, wrap strings in \code{\link[=get-attr]{get-attr()}}
 to extract named attributes. If a component is not present, the value of
 \code{.default} will be returned.}
 

--- a/man/modify.Rd
+++ b/man/modify.Rd
@@ -48,7 +48,7 @@ This syntax allows you to create very compact anonymous functions.
 If \strong{character vector}, \strong{numeric vector}, or \strong{list}, it
 is converted to an extractor function. Character vectors index by name
 and numeric vectors index by position; use a list to index by position
-and name at different levels. Within a list, wrap strings in \code{get_attr()}
+and name at different levels. Within a list, wrap strings in \code{\link[=get-attr]{get-attr()}}
 to extract named attributes. If a component is not present, the value of
 \code{.default} will be returned.}
 

--- a/man/safely.Rd
+++ b/man/safely.Rd
@@ -33,7 +33,7 @@ This syntax allows you to create very compact anonymous functions.
 If \strong{character vector}, \strong{numeric vector}, or \strong{list}, it
 is converted to an extractor function. Character vectors index by name
 and numeric vectors index by position; use a list to index by position
-and name at different levels. Within a list, wrap strings in \code{get_attr()}
+and name at different levels. Within a list, wrap strings in \code{\link[=get-attr]{get-attr()}}
 to extract named attributes. If a component is not present, the value of
 \code{.default} will be returned.}
 


### PR DESCRIPTION
`get-attr()` function is written `get_attr()`.
This PR fixes this typo and creates links to `get-attr()` manual page.
Documentation files are updated.