### PR TITLE
Added mapper support for compose

### DIFF
--- a/R/compose.R
+++ b/R/compose.R
@@ -1,6 +1,6 @@
 #' Compose multiple functions
 #'
-#' @param ... n functions to apply in order from right to left.
+#' @param ... n functions to apply in order from right to left. Args can be symbols, character vector, functions or one side formula.
 #' @return A function
 #'
 #' @export

--- a/R/compose.R
+++ b/R/compose.R
@@ -2,16 +2,20 @@
 #'
 #' @param ... n functions to apply in order from right to left.
 #' @return A function
+#'
 #' @export
 #' @examples
-#' not_null <- compose(`!`, is.null)
+#' not_null <- compose(`!`, "is.null")
 #' not_null(4)
 #' not_null(NULL)
 #'
 #' add1 <- function(x) x + 1
 #' compose(add1, add1)(8)
 compose <- function(...) {
-  fs <- lapply(list(...), match.fun)
+  # characters args are get() to mimic
+  # match.fun behavior
+  args <- modify_if(list(...), is.character, get)
+  fs <- lapply(args, as_mapper)
   n <- length(fs)
 
   last <- fs[[n]]
@@ -25,3 +29,5 @@ compose <- function(...) {
     out
   }
 }
+
+

--- a/man/compose.Rd
+++ b/man/compose.Rd
@@ -7,7 +7,7 @@
 compose(...)
 }
 \arguments{
-\item{...}{n functions to apply in order from right to left.}
+\item{...}{n functions to apply in order from right to left. Args can be symbols, character vector, functions or one side formula.}
 }
 \value{
 A function

--- a/man/compose.Rd
+++ b/man/compose.Rd
@@ -16,7 +16,7 @@ A function
 Compose multiple functions
 }
 \examples{
-not_null <- compose(`!`, is.null)
+not_null <- compose(`!`, "is.null")
 not_null(4)
 not_null(NULL)
 

--- a/tests/testthat/test-compose.R
+++ b/tests/testthat/test-compose.R
@@ -7,3 +7,10 @@ test_that("composed functions are applied right to left", {
   x <- sample(1:4, 100, replace = TRUE)
   expect_identical(unname(sort(table(x))), compose(unname, sort, table)(x))
 })
+
+test_that("functions, mappers and characters can be used", {
+  expect_identical(!is.null(4), compose(`!`, "is.null")(4))
+  expect_identical(!is.null(4), compose(`!`, is.null)(4))
+  expect_identical(!is.null(4), compose(`!`, function(x) is.null(x))(4))
+  expect_identical(!is.null(4), compose(`!`, ~ is.null(.x))(4))
+})


### PR DESCRIPTION
This allows to use mappers inside `compose` : 

```r
clean_lm <- compose(~ arrange(.x, desc(p.value)), 
                    ~ filter(.x, p.value < 0.05),
                    tidy, 
                    summary, 
                    lm)

clean_lm(Sepal.Length ~ Sepal.Width, data = iris)
```

instead of 

```r
clean_lm <- compose(as_mapper(~ arrange(.x, desc(p.value))), 
                    as_mapper(~ filter(.x, p.value < 0.05)),
                    tidy, 
                    summary, 
                    lm)
clean_lm(Sepal.Length ~ Sepal.Width, data = iris)

```
The ` args <- modify_if(list(...), is.character, get)` is there so you can still mimic the `match.fun` behavior, which can take a character object.