### PR TITLE
Fix for duplicate names in list_recurse()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,9 @@
 
 * `map()` and `modify()` now work with calls and pairlists (#412).
 
+* `list_modify()`, `update_list()` and `list_merge()` now handle duplicate
+  duplicate argument names correctly (#441, @mgirlich).
+
 # purrr 0.2.4
 
 * Fixes for R 3.1.

--- a/R/list-modify.R
+++ b/R/list-modify.R
@@ -75,11 +75,12 @@ list_recurse <- function(x, y, base_case) {
       }
     }
   } else if (is_names(x_names) && is_names(y_names)) {
-    for (nm in y_names) {
-      if (has_name(x, nm) && is_list(x[[nm]]) && is_list(y[[nm]])) {
-        x[[nm]] <- list_recurse(x[[nm]], y[[nm]], base_case)
+    for (i in seq_along(y_names)) {
+      nm <- y_names[[i]]
+      if (has_name(x, nm) && is_list(x[[nm]]) && is_list(y[[i]])) {
+        x[[nm]] <- list_recurse(x[[nm]], y[[i]], base_case)
       } else {
-        x[[nm]] <- base_case(x[[nm]], y[[nm]])
+        x[[nm]] <- base_case(x[[nm]], y[[i]])
       }
     }
   } else {

--- a/tests/testthat/test-list-modify-update.R
+++ b/tests/testthat/test-list-modify-update.R
@@ -39,6 +39,11 @@ test_that("lists are replaced recursively", {
   )
 })
 
+test_that("duplicate names works", {
+  expect_equal(list_modify(list(x = 1), x = 2, x = 3), list(x = 3))
+})
+
+
 
 # list_merge --------------------------------------------------------------
 
@@ -64,6 +69,9 @@ test_that("list_merge returns the non-empty list", {
   expect_equal(list_merge(list(), 2), set_names(list(2), ""))
 })
 
+test_that("list_merge handles duplicate names", {
+  expect_equal(list_merge(list(x = 1), x = 2, x = 3), list(x = 1:3))
+})
 
 # update_list ------------------------------------------------------------
 


### PR DESCRIPTION
Currently, `list_modify()`, `update_list()` and `list_merge()` give wrong results when there are duplicate names in the dots argument, e.g.

```
list_modify(list(x = 1), x = 2, x = 3)
# actual result
#> $x
#> [1] 2

# expected result
#> $x
#> [1] 3

list_merge(list(x = 1), x = 2, x = 3)
# actual result
#> $x
#> [1] 1 2 2

# expected result
#> $x
#> [1] 1 2 3
```

In the above example it is of course not very useful. But when splicing with `!!!` this looks useful to me.
The pull request fixes the underlying function `list_recurse()` so that it handles duplicate names correctly.