### PR TITLE
Fix .id arg missing in imap_dfr

### DIFF
--- a/R/flatten.R
+++ b/R/flatten.R
@@ -57,6 +57,10 @@ flatten_chr <- function(.x) {
 #' @export
 #' @rdname flatten
 flatten_dfr <- function(.x, .id = NULL) {
+  if (!is_installed("dplyr")) {
+    abort("`flatten_dfr()` requires dplyr")
+  }
+
   res <- .Call(flatten_impl, .x)
   dplyr::bind_rows(res, .id = .id)
 }
@@ -64,6 +68,10 @@ flatten_dfr <- function(.x, .id = NULL) {
 #' @export
 #' @rdname flatten
 flatten_dfc <- function(.x) {
+  if (!is_installed("dplyr")) {
+    abort("`flatten_dfc()` requires dplyr")
+  }
+
   res <- .Call(flatten_impl, .x)
   dplyr::bind_cols(res)
 }

--- a/R/imap.R
+++ b/R/imap.R
@@ -51,12 +51,12 @@ imap_dbl <- function(.x, .f, ...) {
 #' @export
 imap_dfr <- function(.x, .f, ..., .id = NULL) {
   .f <- as_mapper(.f, ...)
-  map2_dfr(.x, vec_index(.x), .f, ...)
+  map2_dfr(.x, vec_index(.x), .f, ..., .id = .id)
 }
 
 #' @rdname imap
 #' @export
-imap_dfc <- function(.x, .f, ..., .id = NULL) {
+imap_dfc <- function(.x, .f, ...) {
   .f <- as_mapper(.f, ...)
   map2_dfc(.x, vec_index(.x), .f, ...)
 }


### PR DESCRIPTION
This is a small PR that fixes #429

+ `.id` argument in `imap_dfr` is now took into account (see reprex below)

+ unused `.id` argument in `imap_dfc` is now suppressed (I did not rebuilt `.Rd` file)

+ Verifying if it was all, I found that in `flatten_df*` verbs there was no check if `dplyr` is installed or not as in `map_df*`, `map2_df*`, and `pmap_df*`. As it is small changes, I have included in this PR rather than opening a new one

### Checking the fix

``` r
library(purrr)
as_tibble_custom <- function(value, name = NULL) {
  tab <- tibble::as_tibble(value)
  if (! is.null(name)) {
    tab$col_id = paste0("col_", name)
  }
  tab
}
# with imap it does not work
list(a = 1, b = 2, c = 3) %>%
  imap_dfr(as_tibble_custom)
#> # A tibble: 3 x 2
#>   value col_id
#>   <dbl> <chr> 
#> 1  1.00 col_a 
#> 2  2.00 col_b 
#> 3  3.00 col_c
list(a = 1, b = 2, c = 3) %>%
  imap_dfr(as_tibble_custom, .id = "name")
#> # A tibble: 3 x 3
#>   name  value col_id
#>   <chr> <dbl> <chr> 
#> 1 a      1.00 col_a 
#> 2 b      2.00 col_b 
#> 3 c      3.00 col_c
```
