### PR TITLE
Don’t use partial matching for attr_getter()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # purrr 0.2.4.9000
 
+* `attr_getter()` no longer uses partial matching. For example,
+  if an `x` object has a `labels` attribute but no `label` attribute,
+  `attr_getter("label")(x)` will no longer extract the `labels`
+  attribute (#460, @huftis).
+
 * `flatten_dfr()` and `flatten_dfc()` now aborts if dplyr is not installed. (#454)
 
 * `imap_dfr()` now works with `.id` argument is provided (#429)

--- a/R/pluck.R
+++ b/R/pluck.R
@@ -16,6 +16,11 @@
 #' Furthermore, `pluck()` never partial-matches unlike `$` which will
 #' select the `disp` object if you write `mtcars$di`.
 #'
+#' `attr_getter()` generates an attribute accessor function;
+#' i.e., it generates a function for extracting an attribute with
+#' a given name. Unlike the base R `attr()` function with default
+#' options, it doesn't use partial matching.
+#'
 #' @details
 #'
 #' Since it handles arbitrary accessor functions, `pluck()` is a type
@@ -83,5 +88,5 @@ pluck <- function(.x, ..., .default = NULL) {
 #' @param attr An attribute name as string.
 attr_getter <- function(attr) {
   force(attr)
-  function(x) attr(x, attr)
+  function(x) attr(x, attr, exact = TRUE)
 }

--- a/man/pluck.Rd
+++ b/man/pluck.Rd
@@ -38,6 +38,11 @@ cruft. Compare: \code{accessor(x[[1]])$foo} to \code{pluck(x, 1, accessor, "foo"
 
 Furthermore, \code{pluck()} never partial-matches unlike \code{$} which will
 select the \code{disp} object if you write \code{mtcars$di}.
+
+\code{attr_getter()} generates an attribute accessor function;
+i.e., it generates a function for extracting an attribute with
+a given name. Unlike the base R \code{attr()} function with default
+options, it doesn't use partial matching.
 }
 \details{
 Since it handles arbitrary accessor functions, \code{pluck()} is a type

--- a/tests/testthat/test-pluck.R
+++ b/tests/testthat/test-pluck.R
@@ -118,6 +118,17 @@ test_that("delegate error handling to Rf_eval()", {
 })
 
 
+# attribute extraction ----------------------------------------------------
+
+test_that("attr_getter() uses exact (non-partial) matching", {
+  x <- 1
+  attr(x, "labels") <- "foo"
+
+  expect_identical(attr_getter("labels")(x), "foo")
+  expect_identical(attr_getter("label")(x), NULL)
+})
+
+
 # environments ------------------------------------------------------------
 
 test_that("pluck errors with invalid indices", {


### PR DESCRIPTION
Changed the `attr_getter()` fuction to no longer uses partial matching.
For example, if an `x` object has a `labels` attribute but no `label`
attribute, `attr_getter("label")(x)` will no longer extract the `labels`
attribute (fixes #460).

Also added some documentation on the `attr_getter()` function.