### PR TITLE
remove pipes where unnecessary

### DIFF
--- a/R/arrays.R
+++ b/R/arrays.R
@@ -45,13 +45,13 @@
 #' # margin argument:
 #' array_tree(x, c(3, 1)) %>% str()
 array_branch <- function(array, margin = NULL) {
-    dim(array) <- dim(array) %||% length(array)
-    margin <- margin %||% seq_along(dim(array))
+  dim(array) <- dim(array) %||% length(array)
+  margin <- margin %||% seq_along(dim(array))
 
   if (length(margin) == 0) {
     list(array)
   } else {
-    apply(array, margin, list) %>% flatten()
+    flatten(apply(array, margin, list))
   }
 }
 
@@ -63,7 +63,7 @@ array_tree <- function(array, margin = NULL) {
 
   if (length(margin) > 1) {
     new_margin <- ifelse(margin[-1] > margin[[1]], margin[-1] - 1, margin[-1])
-    apply(array, margin[[1]], . %>% array_tree(new_margin))
+    apply(array, margin[[1]], array_tree, new_margin)
   } else {
     array_branch(array, margin)
   }

--- a/R/keep.R
+++ b/R/keep.R
@@ -44,5 +44,5 @@ discard <- function(.x, .p, ...) {
 #' @rdname keep
 compact <- function(.x, .p = identity) {
   .f <- as_mapper(.p)
-  .x %>% discard(function(x) is_empty(.f(x)))
+  discard(.x, function(x) is_empty(.f(x)))
 }

--- a/R/lmap.R
+++ b/R/lmap.R
@@ -76,14 +76,14 @@
 #' iris %>% lmap_if(is.factor, disjoin)
 #' mtcars %>% lmap_at(c("cyl", "vs", "am"), disjoin)
 lmap <- function(.x, .f, ...) {
-  .x %>% lmap_at(seq_along(.x), .f, ...)
+  lmap_at(.x, seq_along(.x), .f, ...)
 }
 
 #' @rdname lmap
 #' @export
 lmap_if <- function(.x, .p, .f, ...) {
-  sel <- probe(.x, .p) %>% which()
-  .x %>% lmap_at(sel, .f, ...)
+  sel <- which(probe(.x, .p))
+  lmap_at(.x, sel, .f, ...)
 }
 
 #' @rdname lmap
@@ -106,5 +106,5 @@ lmap_at <- function(.x, .at, .f, ...) {
     out[[i]] <- res
   }
 
-  flatten(out) %>% maybe_as_data_frame(.x)
+  maybe_as_data_frame(flatten(out), .x)
 }

--- a/R/map2-pmap.R
+++ b/R/map2-pmap.R
@@ -217,7 +217,7 @@ pmap_df <- pmap_dfr
 #' @rdname map2
 pwalk <- function(.l, .f, ...) {
   .f <- as_mapper(.f, ...)
-  args_list <- recycle_args(.l) %>% transpose()
+  args_list <- transpose(recycle_args(.l))
   for (args in args_list) {
     do.call(".f", c(args, list(...)))
   }


### PR DESCRIPTION
There are some uses of pipe inside function definitions where removing those doesn't affect readability. But they unnecessarily increase computation time. Not by much but once used in loops the difference might be significant.

```
require(purrr)
microbenchmark::microbenchmark(
  identity(1), 1 %>% identity(),
  identity(identity(1)), 1 %>% identity() %>% identity(),
  unit = 'us'
)
#> Unit: microseconds
#>                            expr    min     lq      mean median       uq     max neval
#>                     identity(1)  0.000  0.001   0.18351  0.001   0.3210   4.491   100
#>                1 %>% identity() 60.942 63.187  70.55381 65.111  67.6770 135.994   100
#>           identity(identity(1))  0.001  0.322   0.56531  0.642   0.6425   1.604   100
#> 1 %>% identity() %>% identity() 92.053 94.940 109.15809 97.666 103.9205 302.137   100
```