### PR TITLE
Make transpose() help a bit more clear

### DIFF
--- a/R/transpose.R
+++ b/R/transpose.R
@@ -11,12 +11,11 @@
 #' transpose operation on a matrix. You can get back the original
 #' input by transposing it twice.
 #'
-#' @param .l A list of vectors to zip. The first element is used as the
-#'   template; you'll get a warning if a sub-list is not the same length as
-#'   the first element.
-#' @param .names For efficiency, `transpose()` usually inspects the
-#'   first component of `.l` to determine the structure. Use `.names`
-#'   if you want to override this default.
+#' @param .l A list of vectors to transpose. The first element is used as the
+#'   template; you'll get a warning if a subsequent element has a different
+#'   length.
+#' @param .names For efficiency, `transpose()` bases the return structure on
+#'   the first component of `.l` by default. Specify `.names` to override this.
 #' @return A list with indexing transposed compared to `.l`.
 #' @export
 #' @examples

--- a/man/transpose.Rd
+++ b/man/transpose.Rd
@@ -7,13 +7,12 @@
 transpose(.l, .names = NULL)
 }
 \arguments{
-\item{.l}{A list of vectors to zip. The first element is used as the
-template; you'll get a warning if a sub-list is not the same length as
-the first element.}
+\item{.l}{A list of vectors to transpose. The first element is used as the
+template; you'll get a warning if a subsequent element has a different
+length.}
 
-\item{.names}{For efficiency, \code{transpose()} usually inspects the
-first component of \code{.l} to determine the structure. Use \code{.names}
-if you want to override this default.}
+\item{.names}{For efficiency, \code{transpose()} bases the return structure on
+the first component of \code{.l} by default. Specify \code{.names} to override this.}
 }
 \value{
 A list with indexing transposed compared to \code{.l}.


### PR DESCRIPTION
I set out to eliminate the confusing use of "usually" here:

> `.names` For efficiency, `transpose()` usually inspects the first component of `.l` to determine the structure.

and tweaked a few other things while I was at it. I did read the code itself.

Motivated by #474.
