### PR TITLE
Fix typo

### DIFF
--- a/R/flatten.R
+++ b/R/flatten.R
@@ -1,8 +1,8 @@
 #' Flatten a list of lists into a simple vector.
 #'
 #' These functions remove a level hierarchy from a list. They are similar to
-#' [unlist()], only ever remove a single layer of hierarchy, and
-#' are type-stable so you always know what the type of the output is.
+#' [unlist()], but they only ever remove a single layer of hierarchy and they
+#' are type-stable, so you always know what the type of the output is.
 #'
 #' @param .x A list of flatten. The contents of the list can be anything for
 #'   `flatten` (as a list is returned), but the contents must match the

--- a/R/list-modify.R
+++ b/R/list-modify.R
@@ -3,7 +3,7 @@
 #' @description
 #'
 #' `list_modify()` and `list_merge()` recursively combine two lists, matching
-#' elements either by name or position. If an sub-element is present in
+#' elements either by name or position. If a sub-element is present in
 #' both lists `list_modify()` takes the value from `y`, and `list_merge()`
 #' concatenates the values together.
 #'

--- a/R/lmap.R
+++ b/R/lmap.R
@@ -6,7 +6,7 @@
 #' \emph{and} return a list (or data frame). Thus, instead of mapping
 #' the elements of a list (as in \code{.x[[i]]}), they apply a
 #' function `.f` to each subset of size 1 of that list (as in
-#' `.x[i]`). We call those those elements `list-elements`).
+#' `.x[i]`). We call those elements `list-elements`).
 #'
 #' Mapping the list-elements `.x[i]` has several advantages. It
 #' makes it possible to work with functions that exclusively take a

--- a/R/map2-pmap.R
+++ b/R/map2-pmap.R
@@ -40,7 +40,7 @@
 #' pmap(list(x, y, z), sum)
 #'
 #' # Matching arguments by position
-#' pmap(list(x, y, z), function(a, b ,c) a / (b + c))
+#' pmap(list(x, y, z), function(a, b, c) a / (b + c))
 #'
 #' # Matching arguments by name
 #' l <- list(a = x, b = y, c = z)

--- a/R/rerun.R
+++ b/R/rerun.R
@@ -6,7 +6,7 @@
 #' @param .n Number of times to run expressions
 #' @param ... Expressions to re-run.
 #' @return A list of length `.n`. Each element of `...` will be
-#'   re-run once for each `.n`. It
+#'   re-run once for each `.n`.
 #'
 #'   There is one special case: if there's a single unnamed input, the second
 #'   level list will be dropped. In this case, `rerun(n, x)` behaves like


### PR DESCRIPTION
In the pmap() examples:

function(a, b ,c) → function(a, b, c)