### PR TITLE
Convert interrupts to a power of two modulus division

### DIFF
--- a/src/flatten.c
+++ b/src/flatten.c
@@ -67,7 +67,7 @@ SEXP flatten_impl(SEXP x) {
           SET_STRING_ELT(names, i, !Rf_isNull(x_names) ? STRING_ELT(x_names, j) : Rf_mkChar(""));
         }
       }
-      if (i % 1000 == 0)
+      if (i % 1024 == 0)
         R_CheckUserInterrupt();
     }
   }
@@ -118,7 +118,7 @@ SEXP vflatten_impl(SEXP x, SEXP type_) {
 
       if (has_names)
         SET_STRING_ELT(names, i, has_names_j ? STRING_ELT(names_j, k) : Rf_mkChar(""));
-      if (i % 1000 == 0)
+      if (i % 1024 == 0)
         R_CheckUserInterrupt();
     }
   }

--- a/src/map.c
+++ b/src/map.c
@@ -24,7 +24,7 @@ SEXP call_loop(SEXP env, SEXP call, int n, SEXPTYPE type) {
 
   SEXP out = PROTECT(Rf_allocVector(type, n));
   for (int i = 0; i < n; ++i) {
-    if (i % 1000 == 0)
+    if (i % 1024 == 0)
       R_CheckUserInterrupt();
 
     INTEGER(i_val)[0] = i + 1;


### PR DESCRIPTION
C compilers typically convert modulus of powers of two to the equivalent
bitwise and, which makes those operations a fair amount faster.

Compare the assembly generated by the two previous and new values
https://godbolt.org/g/1LAov4

This is admittedly minor, but as this check needs to occur every loop
iteration it can add up.