### PR TITLE
Fix compatibility for dplyr 0.7.5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,20 +10,21 @@ Description: A complete and consistent functional programming toolkit for R.
 License: GPL-3 | file LICENSE
 URL: http://purrr.tidyverse.org, https://github.com/tidyverse/purrr
 BugReports: https://github.com/tidyverse/purrr/issues
-Depends:
+Depends: 
     R (>= 3.1)
-Imports:
+Imports: 
     magrittr (>= 1.5),
     rlang (>= 0.1),
     tibble
-Suggests:
+Suggests: 
     covr,
-    dplyr (>= 0.4.3),
+    dplyr (>= 0.7.4.9003),
     knitr,
     rmarkdown,
     testthat
 VignetteBuilder: knitr
+Encoding: UTF-8
 LazyData: true
+Remotes: tidyverse/dplyr
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.0.1
-Encoding: UTF-8

--- a/tests/testthat/test-flatten.R
+++ b/tests/testthat/test-flatten.R
@@ -75,5 +75,5 @@ test_that("preserves inner names", {
 
 test_that("can flatten to a data frame with named lists", {
   expect_is(flatten_dfr(list(c(a = 1), c(b = 2))), "data.frame")
-  expect_error(flatten_dfc(list(1)))
+  expect_equal(flatten_dfc(list(1)), tibble::tibble(V1 = 1))
 })


### PR DESCRIPTION
by adapting test that checks for an error where there now is none.