### PR TITLE
correct order of argument in reduce2_right

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,11 @@
 # purrr 0.2.5.9000
 
+## Breaking change
+
 * In `reduce2_right()`, `.y` and `.f` are now correctly passed through internal
 `reduce2_impl()`, in keeping with the documentation and `reduce_right()`.
 Previously, and incorrectly, `.y` and `.f` had their behavior reversed. If you
-inverted `.y` and `.f` to make it works, you should now revert back the order
-(#500, @cderv).
+inverted `.y` and `.f` to make it works, you should now revert back the order.
 
 ```R
 paste2 <- function(x, y, sep = ".") paste(x, y, sep = sep)
@@ -18,6 +19,11 @@ reduce2_right(.x = letters[1:4], .y = c("-", ".", "-"), .f = paste2) # error
 # working 
 reduce2_right(.x = letters[1:4], .y = paste2, .f = c("-", ".", "-")) # working
 ```
+
+## Minor improvements and fixes
+
+* In `reduce2_right()`, `.y` and `.f` are now correctly passed through internal
+`reduce2_impl()`, in keeping with the documentation and `reduce_right()` (#500, @cderv).
 
 * `pmap()` and `pwalk()` now preserve class for inputs of `factor`, `Date`, `POSIXct`
   and other atomic S3 classes with an appropriate `[[` method (#358, @mikmart).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,24 @@
 # purrr 0.2.5.9000
 
+* In `reduce2_right()`, `.y` and `.f` are now correctly passed through internal
+`reduce2_impl()`, in keeping with the documentation and `reduce_right()`.
+Previously, and incorrectly, `.y` and `.f` had their behavior reversed. If you
+inverted `.y` and `.f` to make it works, you should now revert back the order
+(#500, @cderv).
+
+```R
+paste2 <- function(x, y, sep = ".") paste(x, y, sep = sep)
+
+## with purrr > 2.5
+reduce2_right(letters[1:4], c("-", ".", "-"), paste2)
+
+## with purrr <= 2.5
+# error
+reduce2_right(.x = letters[1:4], .y = c("-", ".", "-"), .f = paste2) # error
+# working 
+reduce2_right(.x = letters[1:4], .y = paste2, .f = c("-", ".", "-")) # working
+```
+
 * `pmap()` and `pwalk()` now preserve class for inputs of `factor`, `Date`, `POSIXct`
   and other atomic S3 classes with an appropriate `[[` method (#358, @mikmart).
 

--- a/R/reduce.R
+++ b/R/reduce.R
@@ -59,7 +59,7 @@ reduce2 <- function(.x, .y, .f, ..., .init) {
 #' @export
 #' @rdname reduce
 reduce2_right <- function(.x, .y, .f, ..., .init) {
-  reduce2_impl(.x, .f, .y, ..., .init = .init, .left = FALSE)
+  reduce2_impl(.x, .y, .f, ..., .init = .init, .left = FALSE)
 }
 
 reduce2_impl <- function(.x, .y, .f, ..., .init, .left = TRUE) {
@@ -178,7 +178,7 @@ accumulate <- function(.x, .f, ..., .init) {
   f <- function(x, y) {
     .f(x, y, ...)
   }
-  
+
   res <- Reduce(f, .x, init = .init, accumulate = TRUE)
   names(res) <- names(.x)
   res
@@ -193,7 +193,7 @@ accumulate_right <- function(.x, .f, ..., .init) {
   f <- function(x, y) {
     .f(y, x, ...)
   }
-  
+
   res <- Reduce(f, .x, init = .init, right = TRUE, accumulate = TRUE)
   names(res) <- names(.x)
   res

--- a/R/reduce.R
+++ b/R/reduce.R
@@ -29,6 +29,7 @@
 #' paste2 <- function(x, y, sep = ".") paste(x, y, sep = sep)
 #' letters[1:4] %>% reduce(paste2)
 #' letters[1:4] %>% reduce2(c("-", ".", "-"), paste2)
+#' letters[1:4] %>% reduce2_right(c("-", ".", "-"), paste2)
 #'
 #' samples <- rerun(2, sample(10, 5))
 #' samples
@@ -40,6 +41,12 @@
 #' x %>% reduce_right(c)
 #' # Equivalent to:
 #' x %>% rev() %>% reduce(c)
+#'
+#' y <- list(c(6, 7), c(8, 9))
+#' reduce2(x, y, paste)
+#' reduce2_right(x, y, paste)
+#' # Equivalent to:
+#' x %>% rev() %>% reduce2(rev(y), paste)
 reduce <- function(.x, .f, ..., .init) {
   reduce_impl(.x, .f, ..., .init = .init, .left = TRUE)
 }

--- a/tests/testthat/test-reduce.R
+++ b/tests/testthat/test-reduce.R
@@ -46,14 +46,16 @@ test_that("basic application works", {
 
   x <- c("a", "b", "c")
   expect_equal(reduce2(x, c("-", "."), paste2), "a-b.c")
+  expect_equal(reduce2_right(x, c("-", "."), paste2), "c.b-a")
   expect_equal(reduce2(x, c(".", "-", "."), paste2, .init = "x"), "x.a-b.c")
+  expect_equal(reduce2_right(x, c(".", "-", "."), paste2, .init = "x"), "x.c-b.a")
 })
 
 test_that("reduce2_right works if lengths match", {
   x <- list(c(0, 1), c(2, 3), c(4, 5))
   y <- list(c(6, 7), c(8, 9))
-  expect_equal(reduce2_right(x, paste, y), c("4 2 8 0 6", "5 3 9 1 7"))
-  expect_error(reduce2_right(y, paste, x))
+  expect_equal(reduce2_right(x, y, paste), c("4 2 8 0 6", "5 3 9 1 7"))
+  expect_error(reduce2_right(y, x, paste))
 })
 
 test_that("reduce returns original input if it was length one", {


### PR DESCRIPTION
Closes #498 

This fix makes `reduce2_rigth()` coherent with documentation and `reduce2()`

Should this be added to _NEWS.md_ as breaking change ? 

Not sure if `reduce2_rigth` was used that way
```r
x <- list(c(0, 1), c(2, 3), c(4, 5)) 
y <- list(c(6, 7), c(8, 9)) 
reduce2_right(x, paste, y)
``` 
and this won't work anymore