### PR TITLE
fix rbernoulli function

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -73,6 +73,19 @@ names2 <- function(x) {
 #' rbernoulli(10)
 #' rbernoulli(100, 0.1)
 rbernoulli <- function(n, p = 0.5) {
+  # cannot let runif catch problems with n because need the value of n in order
+  # to truncate prob
+  if (length(n) == 0) {
+    return(logical(0))
+  } else if (length(n) == 1 && n == 0) {
+    return(logical(0))
+  } else if (length(n) > 1) {
+    n <- length(n)
+  }
+  # truncate to at most n probs
+  if (length(p) > n) {
+    p <- p[seq_len(n)]
+  }
   stats::runif(n) > (1 - p)
 }
 

--- a/tests/testthat/test-rbernoulli.R
+++ b/tests/testthat/test-rbernoulli.R
@@ -1,0 +1,32 @@
+context("rbernoulli")
+
+test_that("rbernouli works with n = 0", {
+  set.seed(213521)
+  expect_equal(rbernoulli(0), logical(0))
+  expect_equal(rbernoulli(NULL), logical(0))
+})
+
+test_that("rbernolli works with n = 1", {
+  set.seed(213521)
+  expect_equal(rbernoulli(1), TRUE)
+})
+
+test_that("rbernoulli works with only n argument", {
+  set.seed(34531)
+  expect_equal(rbernoulli(5), c(TRUE, TRUE, TRUE, FALSE, FALSE))
+})
+
+test_that("rbernoulli works with one n and multple p", {
+  set.seed(235)
+  expect_equal(rbernoulli(2, c(0.1, 0.2)), c(TRUE, FALSE))
+})
+
+test_that("rbernoulli works with n set by length of n", {
+  set.seed(2351)
+  expect_equal(rbernoulli(c("a", "b"), c(0.1, 0.2)), c(FALSE, FALSE))
+})
+
+test_that("rbernoulli works with n = 1, and multiple p", {
+  set.seed(12351)
+  expect_equal(rbernoulli(1, c(0.1, 0.2)), FALSE)
+})


### PR DESCRIPTION
rbernoulli was generating incorrect results due to recycling of n and p arguments. Make argument handling more consistent with other r* distribution functions.

This PR fixes issue #466.