### PR TITLE
add condition of length 1 to map_*

### DIFF
--- a/R/map.R
+++ b/R/map.R
@@ -13,7 +13,7 @@
 #'   determines which elements of `.x` are transformed with `.f`.
 #'
 #' * `map_lgl()`, `map_int()`, `map_dbl()` and `map_chr()` return
-#'   vectors of the corresponding type (or die trying).
+#'   vectors of *length 1* of the corresponding type (or die trying).
 #'
 #' * `map_dfr()` and `map_dfc()` return data frames created by
 #'   row-binding and column-binding respectively. They require dplyr

--- a/R/map.R
+++ b/R/map.R
@@ -12,8 +12,13 @@
 #'   The `_if` and `_at` variants take a predicate function `.p` that
 #'   determines which elements of `.x` are transformed with `.f`.
 #'
-#' * `map_lgl()`, `map_int()`, `map_dbl()` and `map_chr()` return
-#'   vectors of *length 1* of the corresponding type (or die trying).
+#' * `map_lgl()`, `map_int()`, `map_dbl()` and `map_chr()` each return
+#'    an atomic vector of the indicated type (or die trying).
+#'
+#'    The return value of `.f` must be of length one for each element of
+#'    `.x`. If `.f` uses an extractor function shortcut, `.default`
+#'    can be specified to handle values that are absent or empty.  See
+#'    [as_mapper()] for more on .default.
 #'
 #' * `map_dfr()` and `map_dfc()` return data frames created by
 #'   row-binding and column-binding respectively. They require dplyr

--- a/R/map.R
+++ b/R/map.R
@@ -18,7 +18,7 @@
 #'    The return value of `.f` must be of length one for each element of
 #'    `.x`. If `.f` uses an extractor function shortcut, `.default`
 #'    can be specified to handle values that are absent or empty.  See
-#'    [as_mapper()] for more on .default.
+#'    [as_mapper()] for more on `.default`.
 #'
 #' * `map_dfr()` and `map_dfc()` return data frames created by
 #'   row-binding and column-binding respectively. They require dplyr

--- a/man/map.Rd
+++ b/man/map.Rd
@@ -102,8 +102,13 @@ type as the input.
 
 The \code{_if} and \code{_at} variants take a predicate function \code{.p} that
 determines which elements of \code{.x} are transformed with \code{.f}.
-\item \code{map_lgl()}, \code{map_int()}, \code{map_dbl()} and \code{map_chr()} return
-vectors of the corresponding type (or die trying).
+\item \code{map_lgl()}, \code{map_int()}, \code{map_dbl()} and \code{map_chr()} each return
+an atomic vector of the indicated type (or die trying).
+
+The return value of \code{.f} must be of length one for each element of
+\code{.x}. If \code{.f} uses an extractor function shortcut, \code{.default}
+can be specified to handle values that are absent or empty.  See
+\code{\link[=as_mapper]{as_mapper()}} for more on .default.
 \item \code{map_dfr()} and \code{map_dfc()} return data frames created by
 row-binding and column-binding respectively. They require dplyr
 to be installed.

--- a/man/map.Rd
+++ b/man/map.Rd
@@ -108,7 +108,7 @@ an atomic vector of the indicated type (or die trying).
 The return value of \code{.f} must be of length one for each element of
 \code{.x}. If \code{.f} uses an extractor function shortcut, \code{.default}
 can be specified to handle values that are absent or empty.  See
-\code{\link[=as_mapper]{as_mapper()}} for more on .default.
+\code{\link[=as_mapper]{as_mapper()}} for more on \code{.default}.
 \item \code{map_dfr()} and \code{map_dfc()} return data frames created by
 row-binding and column-binding respectively. They require dplyr
 to be installed.


### PR DESCRIPTION
This makes it clearer that only a single value can be returned, which is kind of unexpected, honestly.

Fixes #518 