### PR TITLE
Fixes oddities with NAs and some() #514

### DIFF
--- a/R/every-some.R
+++ b/R/every-some.R
@@ -26,10 +26,12 @@ every <- function(.x, .p, ...) {
 #' @rdname every
 some <- function(.x, .p, ...) {
   .p <- as_mapper(.p, ...)
+  no_na <- TRUE
   for (i in seq_along(.x)) {
     val <- .p(.x[[i]], ...)
     if (is_true(val)) return(TRUE)
-    if (anyNA(val)) return(NA)
+    if (no_na && anyNA(val)) no_na <- FALSE
   }
-  FALSE
+  if (no_na) FALSE
+  NA
 }

--- a/R/every-some.R
+++ b/R/every-some.R
@@ -33,5 +33,5 @@ some <- function(.x, .p, ...) {
     if (no_na && anyNA(val)) no_na <- FALSE
   }
   if (no_na) FALSE
-  NA
+  else NA
 }


### PR DESCRIPTION
Changes `some` to follow logic as seen in #514, i.e.

> If the condition is TRUE for at least one element, return TRUE.
    If FALSE for all and has NA - return NA (We do not have information about NA)
    Otherwise - FALSE
