### PR TITLE
Refine safely() return value documentation (#488)

### DIFF
--- a/R/output.R
+++ b/R/output.R
@@ -11,7 +11,9 @@
 #' @param otherwise Default value to use when an error occurs.
 #'
 #' @return `safely`: wrapped function instead returns a list with
-#'   components `result` and `error`. One value is always `NULL`.
+#'   components `result` and `error`. If an error occurred, `error` is
+#'   an `error` object and `result` has a default value (`otherwise`).
+#'   Else `error` is `NULL`.
 #'
 #'   `quietly`: wrapped function instead returns a list with components
 #'   `result`, `output`, `messages` and `warnings`.

--- a/man/safely.Rd
+++ b/man/safely.Rd
@@ -44,7 +44,9 @@ as they occur?}
 }
 \value{
 \code{safely}: wrapped function instead returns a list with
-components \code{result} and \code{error}. One value is always \code{NULL}.
+components \code{result} and \code{error}. If an error occurred, \code{error} is
+an \code{error} object and \code{result} has a default value (\code{otherwise}).
+Else \code{error} is \code{NULL}.
 
 \code{quietly}: wrapped function instead returns a list with components
 \code{result}, \code{output}, \code{messages} and \code{warnings}.


### PR DESCRIPTION
Reworded the documented return value for `safely()`. This fixes #488.

Suggested new wording:

> `safely`: wrapped function instead returns a list with components `result` and `error`. If an error occurred, `error` is an `error` object and `result` has a default value (`otherwise`). Else `error` is `NULL`.

Since the default value of `otherwise` for `safely()` is `NULL`, this wording also covers the previous "one is always `NULL`" behaviour when an `otherwise` value is not explicitly given.

As to when there's no error, I think it's probably sufficient to not explicitly state that then `return` contains the return value of the wrapped function?