### PR TITLE
Evaluates .ragged in modify_depth before modifying .depth

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # purrr 0.2.4.9000
 
+* `modify_depth` now has `.ragged` argument evaluates correctly to `TRUE` by
+default when `.depth < 0` (@cderv, #530)
+
 * `accumulate()` and `accumulate_right()` now inherit names from their first input (@AshesITR, #446)
 
 * `attr_getter()` no longer uses partial matching. For example,

--- a/R/modify.R
+++ b/R/modify.R
@@ -202,6 +202,7 @@ modify_depth <- function(.x, .depth, .f, ..., .ragged = .depth < 0) {
 #' @export
 modify_depth.default <- function(.x, .depth, .f, ..., .ragged = .depth < 0) {
   stopifnot(is_integerish(.depth, n = 1))
+  force(.ragged)
 
   if (.depth < 0) {
     .depth <- vec_depth(.x) + .depth

--- a/tests/testthat/test-modify.R
+++ b/tests/testthat/test-modify.R
@@ -83,4 +83,6 @@ test_that(".ragged = TRUE operates on leaves", {
 
   expect_equal(modify_depth(x1, 3, ~ . + 1, .ragged = TRUE), x2)
   expect_equal(modify_depth(x1, -1, ~ . + 1, .ragged = TRUE), x2)
+  # .ragged should be TRUE is .depth < 0
+  expect_equal(modify_depth(x1, -1, ~ . + 1), x2)
 })


### PR DESCRIPTION
This fixes #530 by forcing evaluation of `.ragged` argument in `modify_depth.default` before modifying `.depth` when it is negative.

It also adds a test to check the correct default behavior.