### PR TITLE
Fix librarys typo in other-langs vignette

### DIFF
--- a/vignettes/other-langs.Rmd
+++ b/vignettes/other-langs.Rmd
@@ -13,7 +13,7 @@ purrr draws inspiration from many related tools:
 
 * Scala's [list methods][scala].
 
-* Functional programming librarys for javascript: 
+* Functional programming libraries for javascript: 
   [underscore.js](http://underscorejs.org), 
   [lodash](https://lodash.com) and 
   [lazy.js](http://danieltao.com/lazy.js/).


### PR DESCRIPTION
Typo fix. 

Didn't rebuild the vignette, since I figured it'll happen in the next round. But, I'm happy to do so, if you think I should.