### PR TITLE
Fix outdated version number

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: purrr
 Title: Functional Programming Tools
-Version: 0.2.4.9000
+Version: 0.2.5.9000
 Authors@R: c(
     person("Lionel", "Henry", , "lionel@rstudio.com", c("aut", "cre")),
     person("Hadley", "Wickham", , "hadley@rstudio.com", "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# purrr 0.2.4.9000
+# purrr 0.2.5.9000
 
 * `accumulate()` and `accumulate_right()` now inherit names from their first input (@AshesITR, #446)
 
@@ -25,6 +25,10 @@
   
 * `map_raw`, `imap_raw`, `flatten_raw`, `invoke_map_raw`, `map2_raw` and `pmap_raw`
   added to support raw vectors. (#455, @romainfrancois)
+
+# purrr 0.2.5
+
+* This is a maintenance release following the release of dplyr 0.7.5.
 
 # purrr 0.2.4
 


### PR DESCRIPTION
As @cderv mentions [here](https://github.com/tidyverse/purrr/issues/429#issuecomment-407148827), an odd thing has happened with purrr's version numbers.

The current CRAN version is 0.2.5, whereas the master branch on GitHub is 0.2.4.9000. The fixes that were implemented between 0.2.4 and 0.2.4.9000 are not included in the 0.2.5 release. That one was a "maintenance release following the release of dplyr 0.7.5", which I guess came in though some other pipeline than the "normal" GitHub path.

I noticed this as I ran into the bug reported in #429 (parameter `.id` is ignored in `imap_dfr()`), for which a fix was merged on Feb 5 in #454. However, while this fix is on the current master branch (0.2.4.9000), it is not included in CRAN's 0.2.5.

The result is that I cannot make my package depend on the fixed version, as 0.2.5 > 0.2.4.9000.

This PR hence bumps the version number on GitHub from 0.2.4.9000 to 0.2.5.9000. Then it is possible to make another package depend on purrr 0.2.5.9000, which does include the needed fix.