### PR TITLE
Preserve classes in pmap()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # purrr 0.2.4.9000
 
+* `pmap()` and `pwalk()` now preserve class for inputs of `factor`, `Date`, `POSIXct`
+  and other atomic S3 classes with an appropriate `[[` method (#358, @mikmart).
+
 * `compose()` now supports composition with lambdas (@ColinFay, #556)
 
 * Fixed a `pmap()` crash with empty lists on the Win32 platform (#565).

--- a/R/map.R
+++ b/R/map.R
@@ -209,9 +209,6 @@ map_dfc <- function(.x, .f, ...) {
 #' @export
 #' @rdname map
 walk <- function(.x, .f, ...) {
-  .f <- as_mapper(.f, ...)
-  for (i in seq_along(.x)) {
-    .f(.x[[i]], ...)
-  }
+  map(.x, .f, ...)
   invisible(.x)
 }

--- a/R/map2-pmap.R
+++ b/R/map2-pmap.R
@@ -147,7 +147,7 @@ map2_df <- map2_dfr
 #' @export
 #' @rdname map2
 walk2 <- function(.x, .y, .f, ...) {
-  pwalk(list(.x, .y), .f, ...)
+  map2(.x, .y, .f, ...)
   invisible(.x)
 }
 
@@ -245,10 +245,6 @@ pmap_df <- pmap_dfr
 #' @export
 #' @rdname map2
 pwalk <- function(.l, .f, ...) {
-  .f <- as_mapper(.f, ...)
-  args_list <- transpose(recycle_args(.l))
-  for (args in args_list) {
-    do.call(".f", c(args, list(...)))
-  }
+  pmap(.l, .f, ...)
   invisible(.l)
 }

--- a/tests/testthat/test-map_n.R
+++ b/tests/testthat/test-map_n.R
@@ -64,3 +64,9 @@ test_that("pmap on data frames performs rowwise operations", {
 test_that("pmap works with empty lists", {
   expect_identical(pmap(list(), identity), list())
 })
+
+test_that("preserves S3 class of input vectors (#358)", {
+  date <- as.Date("2018-09-27")
+  expect_equal(pmap(list(date), identity), list(date))
+  expect_output(pwalk(list(date), print), format(date))
+})


### PR DESCRIPTION
Following [this suggestion](https://github.com/tidyverse/purrr/issues/358#issuecomment-386840204), changed the calls constructed by `pmap()` to use two double brackets for indexing rather than a single double bracket with a vector argument. This retains class for S3 atomic vector types (whose `[[` method preserves the class) in the input. Fixes #358.

However, list-based S3 classes, e.g. `POSIXlt` still fail.