### PR TITLE
Fix pmap() with empty list on Win32

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
+^appveyor\.yml$
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^\.travis\.yml$

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # purrr 0.2.4.9000
 
+* Fixed a `pmap()` crash with empty lists on the Win32 platform (#565).
+
 * `modify_depth` now has `.ragged` argument evaluates correctly to `TRUE` by
 default when `.depth < 0` (@cderv, #530)
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -18,6 +18,7 @@ knitr::opts_chunk$set(
 
 [![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/purrr)](http://cran.r-project.org/package=purrr)
 [![Build Status](https://travis-ci.org/tidyverse/purrr.svg?branch=master)](https://travis-ci.org/tidyverse/purrr)
+[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/tidyverse/purrr?branch=master&svg=true)](https://ci.appveyor.com/project/tidyverse/purrr)
 [![Coverage Status](https://img.shields.io/codecov/c/github/tidyverse/purrr/master.svg)](https://codecov.io/github/tidyverse/purrr?branch=master)
 
 ## Overview

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,45 @@
+# DO NOT CHANGE the "init" and "install" sections below
+
+# Download script file from GitHub
+init:
+  ps: |
+        $ErrorActionPreference = "Stop"
+        Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
+        Import-Module '..\appveyor-tool.ps1'
+
+install:
+  ps: Bootstrap
+
+cache:
+  - C:\RLibrary
+
+# Adapt as necessary starting from here
+
+build_script:
+  - travis-tool.sh install_deps
+
+test_script:
+  - travis-tool.sh run_tests
+
+on_failure:
+  - 7z a failure.zip *.Rcheck\*
+  - appveyor PushArtifact failure.zip
+
+artifacts:
+  - path: '*.Rcheck\**\*.log'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.out'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.fail'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.Rout'
+    name: Logs
+
+  - path: '\*_*.tar.gz'
+    name: Bits
+
+  - path: '\*_*.zip'
+    name: Bits

--- a/src/map.c
+++ b/src/map.c
@@ -201,7 +201,10 @@ SEXP pmap_impl(SEXP env, SEXP l_name_, SEXP f_name_, SEXP type_) {
   REPROTECT(f_call = Rf_lcons(f, f_call), fi);
 
   SEXP out = PROTECT(call_loop(env, f_call, n, type, m));
-  copy_names(VECTOR_ELT(l_val, 0), out);
+
+  if (Rf_length(l_val)) {
+    copy_names(VECTOR_ELT(l_val, 0), out);
+  }
 
   UNPROTECT(5);
   return out;

--- a/tests/testthat/test-map_n.R
+++ b/tests/testthat/test-map_n.R
@@ -60,3 +60,7 @@ test_that("pmap on data frames performs rowwise operations", {
   expect_is(pmap_chr(mtcars2, paste), "character")
   expect_is(pmap_raw(mtcars2, function(mpg, cyl) as.raw(cyl)), "raw")
 })
+
+test_that("pmap works with empty lists", {
+  expect_identical(pmap(list(), identity), list())
+})


### PR DESCRIPTION
Fixes #565.

Enables Appveyor, even though I couldn't produce a crashing test. It crashes locally but not on Appveyor. Still seems safer to test on Appveyor to get the 32 bit checks.