### PR TITLE
Added test on uncovered line in possibly()

### DIFF
--- a/tests/testthat/test-output.R
+++ b/tests/testthat/test-output.R
@@ -37,6 +37,12 @@ test_that("possibly returns default value on failure", {
   expect_identical(possibly(log, NA_real_)("a"), NA_real_)
 })
 
+test_that("possibly emits a message on failure if quiet = FALSE", {
+  expect_message({
+    possibly(log, NA_real_, quiet = FALSE)("a")
+  }, regexp = "non-numeric argument to mathematical function")
+})
+
 test_that("auto_browse() not intended for primitive functions", {
   expect_error(auto_browse(log)(NULL), "primitive functions")
   expect_error(auto_browse(identity)(NULL), NA)


### PR DESCRIPTION
As of now, this portion of `possibly()` is not covered by this project's tests:

```
if (!quiet)
    message("Error: ", e$message)
```

Please consider this PR to add a test that covers it.