### PR TITLE
removed unreachable line in make_call()

### DIFF
--- a/R/partial.R
+++ b/R/partial.R
@@ -82,6 +82,5 @@ partial <- function(...f, ..., .env = parent.frame(), .lazy = TRUE,
 }
 
 make_call <- function(f, ..., .args = list()) {
-  if (is.character(f)) f <- as.name(f)
   as.call(c(f, ..., .args))
 }


### PR DESCRIPTION
Thank you for this awesome package! I hope you'll consider this PR to remove this unreachable line in internal function `make_call()`

![image](https://user-images.githubusercontent.com/7608904/48982034-b9f4da80-f0a2-11e8-84b3-6bb9a8b02b3c.png)

Because `make_call()` is only called by `partial()` and `partial()` has this:

```
stopifnot(is.function(...f))
```

It's impossible for a value of `f` that is anything other than a function to reach that `make_call()` call.