### PR TITLE
Fix `accumulate()` return value and documentation when `.init` is supplied

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -59,6 +59,9 @@ reduce2_right(.x = letters[1:4], .y = paste2, .f = c("-", ".", "-")) # working
 
 ## Minor improvements and fixes
 
+* Fixed ordering of names returned by `accumulate_right()`
+  output. They now correspond to the order of inputs.
+
 * Fixed names of `accumulate()` output when `.init` is supplied.
 
 * New `modify2()` and `imodify()` functions. These work like `map()`

--- a/NEWS.md
+++ b/NEWS.md
@@ -59,6 +59,8 @@ reduce2_right(.x = letters[1:4], .y = paste2, .f = c("-", ".", "-")) # working
 
 ## Minor improvements and fixes
 
+* Fixed names of `accumulate()` output when `.init` is supplied.
+
 * New `modify2()` and `imodify()` functions. These work like `map()`
   and `imap()` but preserve the type of `.x` in the return value.
 

--- a/R/reduce.R
+++ b/R/reduce.R
@@ -207,17 +207,22 @@ accumulate_right <- function(.x, .f, ..., .init) {
   }
 
   res <- Reduce(f, .x, init = .init, right = TRUE, accumulate = TRUE)
-  names(res) <- accumulate_names(names(.x), .init)
+  names(res) <- accumulate_names(names(.x), .init, right = TRUE)
 
   res
 }
 
-accumulate_names <- function(nms, init) {
-  if (!is_null(nms)) {
-    if (missing(init)) {
-      nms
-    } else {
-      c(".init", nms)
-    }
+accumulate_names <- function(nms, init, right = FALSE) {
+  if (is_null(nms)) {
+    return(NULL)
   }
+
+  if (!missing(init)) {
+    nms <- c(".init", nms)
+  }
+  if (right) {
+    nms <- rev(nms)
+  }
+
+  nms
 }

--- a/R/reduce.R
+++ b/R/reduce.R
@@ -187,7 +187,8 @@ accumulate <- function(.x, .f, ..., .init) {
   }
 
   res <- Reduce(f, .x, init = .init, accumulate = TRUE)
-  names(res) <- names(.x)
+  names(res) <- accumulate_names(names(.x), .init)
+
   res
 }
 
@@ -202,6 +203,17 @@ accumulate_right <- function(.x, .f, ..., .init) {
   }
 
   res <- Reduce(f, .x, init = .init, right = TRUE, accumulate = TRUE)
-  names(res) <- names(.x)
+  names(res) <- accumulate_names(names(.x), .init)
+
   res
+}
+
+accumulate_names <- function(nms, init) {
+  if (!is_null(nms)) {
+    if (missing(init)) {
+      nms
+    } else {
+      c(".init", nms)
+    }
+  }
 }

--- a/R/reduce.R
+++ b/R/reduce.R
@@ -150,7 +150,11 @@ seq_len2 <- function(start, end) {
 #'
 #' @inheritParams reduce
 #'
-#' @return A vector the same length of `.x` with the same names as `.x`
+#' @return A vector the same length of `.x` with the same names as `.x`.
+#'
+#'   If `.init` is supplied, the length is extended by 1. If `.x` has
+#'   names, the initial value is given the name `".init"`, otherwise
+#'   the returned vector is kept unnamed.
 #' @export
 #' @examples
 #' 1:3 %>% accumulate(`+`)

--- a/man/accumulate.Rd
+++ b/man/accumulate.Rd
@@ -28,7 +28,11 @@ you want to ensure that \code{reduce} returns a correct value when \code{.x}
 is empty. If missing, and \code{x} is empty, will throw an error.}
 }
 \value{
-A vector the same length of \code{.x} with the same names as \code{.x}
+A vector the same length of \code{.x} with the same names as \code{.x}.
+
+If \code{.init} is supplied, the length is extended by 1. If \code{.x} has
+names, the initial value is given the name \code{".init"}, otherwise
+the returned vector is kept unnamed.
 }
 \description{
 \code{accumulate} applies a function recursively over a list from the left, while

--- a/tests/testthat/test-reduce.R
+++ b/tests/testthat/test-reduce.R
@@ -39,6 +39,11 @@ test_that("accumulate keeps input names", {
   expect_identical(accumulate_right(input, sum), set_names(rev(cumsum(rev(1:26))), letters))
 })
 
+test_that("accumulate keeps input names when init is supplied", {
+  expect_identical(accumulate(1:2, c, .init = 0L), list(0L, 0:1, 0:2))
+  expect_identical(accumulate(c(a = 1L, b = 2L), c, .init = 0L), list(.init = 0L, a = 0:1, b = 0:2))
+})
+
 # reduce2 -----------------------------------------------------------------
 
 test_that("basic application works", {

--- a/tests/testthat/test-reduce.R
+++ b/tests/testthat/test-reduce.R
@@ -36,12 +36,15 @@ test_that("accumulate passes arguments to function", {
 test_that("accumulate keeps input names", {
   input <- set_names(1:26, letters)
   expect_identical(accumulate(input, sum), set_names(cumsum(1:26), letters))
-  expect_identical(accumulate_right(input, sum), set_names(rev(cumsum(rev(1:26))), letters))
+  expect_identical(accumulate_right(input, sum), set_names(rev(cumsum(rev(1:26))), rev(letters)))
 })
 
 test_that("accumulate keeps input names when init is supplied", {
   expect_identical(accumulate(1:2, c, .init = 0L), list(0L, 0:1, 0:2))
   expect_identical(accumulate(c(a = 1L, b = 2L), c, .init = 0L), list(.init = 0L, a = 0:1, b = 0:2))
+
+  expect_identical(accumulate_right(0:1, c, .init = 2L), list(2:0, 2:1, 2L))
+  expect_identical(accumulate_right(c(a = 0L, b = 1L), c, .init = 2L), list(b = 2:0, a = 2:1, .init = 2L))
 })
 
 # reduce2 -----------------------------------------------------------------


### PR DESCRIPTION
* Properly handle names when `.init` is supplied. The initial value gets the name `".init"`, which is consistent with the argument name and the new convention of prepending generated names with a dot. Does that sound reasonable?

* Clearer documentation about the return value. Closes #569.