### PR TITLE
Retain dimnames in array_branch and array_tree

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -125,6 +125,9 @@ default when `.depth < 0` (@cderv, #530)
 * `some()` now returns `NA` only after it has checked all other predicates are 
   either `NA` or `FALSE` (@daniel-barnett, #514).
 
+* `array_branch()` and `array_tree()` now retain the `dimnames()` of the input
+  array (#584, @flying-sheep)
+
 # purrr 0.2.5
 
 * This is a maintenance release following the release of dplyr 0.7.5.

--- a/R/arrays.R
+++ b/R/arrays.R
@@ -50,7 +50,12 @@ array_branch <- function(array, margin = NULL) {
 
   if (length(margin) == 0) {
     list(array)
-  } else if (identical(as.integer(margin), 1L) && is.null(dim(array))) {
+  } else if (is.null(dim(array))) {
+    if (!identical(as.integer(margin), 1L)) {
+      stop(
+        "The passed array is 1D and does not have the margin(s) ",
+        toString(margin), call. = FALSE)
+    }
     as.list(array)
   } else {
     flatten(apply(array, margin, list))

--- a/R/arrays.R
+++ b/R/arrays.R
@@ -50,6 +50,8 @@ array_branch <- function(array, margin = NULL) {
 
   if (length(margin) == 0) {
     list(array)
+  } else if (identical(margin, 1) && is.null(dim(array))) {
+    as.list(array)
   } else {
     flatten(apply(array, margin, list))
   }

--- a/R/arrays.R
+++ b/R/arrays.R
@@ -50,7 +50,7 @@ array_branch <- function(array, margin = NULL) {
 
   if (length(margin) == 0) {
     list(array)
-  } else if (identical(margin, 1) && is.null(dim(array))) {
+  } else if (identical(as.integer(margin), 1L) && is.null(dim(array))) {
     as.list(array)
   } else {
     flatten(apply(array, margin, list))

--- a/R/arrays.R
+++ b/R/arrays.R
@@ -45,8 +45,8 @@
 #' # margin argument:
 #' array_tree(x, c(3, 1)) %>% str()
 array_branch <- function(array, margin = NULL) {
-  dim(array) <- dim(array) %||% length(array)
-  margin <- margin %||% seq_along(dim(array))
+  dims <- dim(array) %||% length(array)
+  margin <- margin %||% seq_along(dims)
 
   if (length(margin) == 0) {
     list(array)
@@ -58,8 +58,8 @@ array_branch <- function(array, margin = NULL) {
 #' @rdname array-coercion
 #' @export
 array_tree <- function(array, margin = NULL) {
-  dim(array) <- dim(array) %||% length(array)
-  margin <- margin %||% seq_along(dim(array))
+  dims <- dim(array) %||% length(array)
+  margin <- margin %||% seq_along(dims)
 
   if (length(margin) > 1) {
     new_margin <- ifelse(margin[-1] > margin[[1]], margin[-1] - 1, margin[-1])

--- a/R/arrays.R
+++ b/R/arrays.R
@@ -52,9 +52,10 @@ array_branch <- function(array, margin = NULL) {
     list(array)
   } else if (is.null(dim(array))) {
     if (!identical(as.integer(margin), 1L)) {
-      stop(
-        "The passed array is 1D and does not have the margin(s) ",
-        toString(margin), call. = FALSE)
+      abort(sprintf(
+        "`margin` must be `NULL` or `1` with 1D arrays, not `%s`",
+        toString(margin)
+      ))
     }
     as.list(array)
   } else {

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,0 +1,1 @@
+Sys.setlocale("LC_MESSAGES", "C")

--- a/tests/testthat/test-arrays.R
+++ b/tests/testthat/test-arrays.R
@@ -16,7 +16,7 @@ test_that("array_branch works on vectors", {
 })
 
 test_that("array_branch throws an error for wrong margins on a vector", {
-  expect_error(array_branch(1:3, 2), "does not have the margin\\(s\\) 2")
+  expect_error(array_branch(1:3, 2), "must be `NULL` or `1`")
 })
 
 test_that("length depends on whether list is flattened or not", {

--- a/tests/testthat/test-arrays.R
+++ b/tests/testthat/test-arrays.R
@@ -10,6 +10,11 @@ test_that("array_branch wraps array in list when margin has length 0", {
   expect_identical(array_branch(x, numeric(0)), list(x))
 })
 
+test_that("array_branch works on vectors", {
+  expect_identical(array_branch(1:3), list(1L, 2L, 3L))
+  expect_identical(array_branch(1:3, 1), list(1L, 2L, 3L))
+})
+
 test_that("length depends on whether list is flattened or not", {
   m1 <- c(3, 1)
   m2 <- 3

--- a/tests/testthat/test-arrays.R
+++ b/tests/testthat/test-arrays.R
@@ -1,6 +1,6 @@
 context("arrays")
 
-x <- array(1:12, c(2, 2, 3))
+x <- array(1:12, c(2, 2, 3), dimnames = list(letters[1:2], LETTERS[1:2], NULL))
 
 test_that("array_branch creates a flat list when no margin specified", {
   expect_length(array_branch(x), 12)
@@ -15,4 +15,10 @@ test_that("length depends on whether list is flattened or not", {
   m2 <- 3
   expect_length(array_branch(x, m1), prod(dim(x)[m1]))
   expect_length(array_tree(x, m1), prod(dim(x)[m2]))
+})
+
+test_that("array_branch retains dimnames when going over one dimension", {
+  expect_identical(names(array_branch(x, 1)), letters[1:2])
+  expect_identical(names(array_branch(x, 2)), LETTERS[1:2])
+  expect_identical(names(array_branch(x, 2:3)[[1]]), letters[1:2])
 })

--- a/tests/testthat/test-arrays.R
+++ b/tests/testthat/test-arrays.R
@@ -15,6 +15,10 @@ test_that("array_branch works on vectors", {
   expect_identical(array_branch(1:3, 1), list(1L, 2L, 3L))
 })
 
+test_that("array_branch throws an error for wrong margins on a vector", {
+  expect_error(array_branch(1:3, 2), "does not have the margin\\(s\\) 2")
+})
+
 test_that("length depends on whether list is flattened or not", {
   m1 <- c(3, 1)
   m2 <- 3


### PR DESCRIPTION
By not resetting `dim(array)` without need, the return value retains its dimnames