### PR TITLE
Add `.rev` argument to `compose()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -64,6 +64,9 @@ reduce2_right(.x = letters[1:4], .y = paste2, .f = c("-", ".", "-")) # working
 
 ## Minor improvements and fixes
 
+* New `.rev` argument in `compose()`. If set to `FALSE`, the functions
+  are composed from left to right rather than right to left.
+
 * New `chuck()` function. This is a strict variant of `pluck()` that
   throws errors when an element does not exist instead of returning
   `NULL` (@daniel-barnett, #482).

--- a/man/compose.Rd
+++ b/man/compose.Rd
@@ -4,15 +4,19 @@
 \alias{compose}
 \title{Compose multiple functions}
 \usage{
-compose(...)
+compose(..., .rev = TRUE)
 }
 \arguments{
-\item{...}{Functions to apply in order from right to left. Formulas
-are converted to functions in the usual way.
+\item{...}{Functions to apply in order (from right to left by
+default). Formulas are converted to functions in the usual way.
 
 These dots support \link[rlang:list2]{tidy dots} features. In
 particular, if your functions are stored in a list, you can
 splice that in with \code{!!!}.}
+
+\item{.rev}{If \code{TRUE} (the default), the functions are called in
+the reverse order, from right to left, as is conventional in
+mathematics. Otherwise they are called from left to right.}
 }
 \value{
 A function

--- a/tests/testthat/test-compose.R
+++ b/tests/testthat/test-compose.R
@@ -1,11 +1,15 @@
 context("compose")
 
-test_that("composed functions are applied right to left", {
+test_that("composed functions are applied right to left by default", {
   expect_identical(!is.null(4), compose(`!`, is.null)(4))
 
   set.seed(1)
   x <- sample(1:4, 100, replace = TRUE)
   expect_identical(unname(sort(table(x))), compose(unname, sort, table)(x))
+})
+
+test_that("composed functions are applied in reverse order if .dir is supplied", {
+  expect_identical(compose(~ .x + 100, ~ .x * 2, .rev = FALSE)(2), 204)
 })
 
 test_that("compose supports formulas", {


### PR DESCRIPTION
Closes #323

I thought about a `.dir` argument but it seemed a bit confusing (does `.dir = "right"` start from the right or composes from left to right?).