### PR TITLE
Require strict predicate functions in purrr

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -64,9 +64,9 @@ reduce2_right(.x = letters[1:4], .y = paste2, .f = c("-", ".", "-")) # working
 
 ## Minor improvements and fixes
 
-* Functions taking predicates (`some()`, `every()`, `keep()`, etc) now
-  fail with an informative message when the return value is not a
-  scalar logical (#470).
+* Functions taking predicates (`map_if()`, `keep()`, `some()`,
+  `every()`, `keep()`, etc) now fail with an informative message when
+  the return value is not `TRUE` or `FALSE` (#470).
 
 * `pluck()` now supports primitive functions (#404).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -68,6 +68,12 @@ reduce2_right(.x = letters[1:4], .y = paste2, .f = c("-", ".", "-")) # working
   `every()`, `keep()`, etc) now fail with an informative message when
   the return value is not `TRUE` or `FALSE` (#470).
 
+  This is a breaking change for `every()` and `some()` which were
+  documented to be more liberal in the values they accepted as logical
+  (any vector was considered `TRUE` if not a single `FALSE` value, no
+  matter its length). These functions signal soft-deprecation warnings
+  instead of a hard failure.
+
 * `pluck()` now supports primitive functions (#404).
 
 * New `.rev` argument in `compose()`. If set to `FALSE`, the functions

--- a/NEWS.md
+++ b/NEWS.md
@@ -64,6 +64,10 @@ reduce2_right(.x = letters[1:4], .y = paste2, .f = c("-", ".", "-")) # working
 
 ## Minor improvements and fixes
 
+* Functions taking predicates (`some()`, `every()`, `keep()`, etc) now
+  fail with an informative message when the return value is not a
+  scalar logical (#470).
+
 * `pluck()` now supports primitive functions (#404).
 
 * New `.rev` argument in `compose()`. If set to `FALSE`, the functions

--- a/R/as_mapper.R
+++ b/R/as_mapper.R
@@ -114,7 +114,7 @@ plucker <- function(i, default) {
   )
 }
 
-as_predicate <- function(.fn, ..., .mapper, .na = FALSE) {
+as_predicate <- function(.fn, ..., .mapper, .deprecate = FALSE) {
   if (.mapper) {
     .fn <- as_mapper(.fn, ...)
   }
@@ -122,11 +122,20 @@ as_predicate <- function(.fn, ..., .mapper, .na = FALSE) {
   function(...) {
     out <- .fn(...)
 
-    if (!is_bool(out, .na)) {
-      abort(sprintf(
+    if (!is_bool(out)) {
+      msg <- sprintf(
         "Predicate functions must return a single logical `TRUE` or `FALSE`, not %s",
         as_predicate_friendly_type_of(out)
-      ))
+      )
+      if (.deprecate) {
+        msg <- paste_line(
+          "Returning complex values from a predicate function is soft-deprecated as of purrr 0.3.0.",
+          msg
+        )
+        signal_soft_deprecated(msg)
+      } else {
+        abort(msg)
+      }
     }
 
     out

--- a/R/as_mapper.R
+++ b/R/as_mapper.R
@@ -114,7 +114,7 @@ plucker <- function(i, default) {
   )
 }
 
-as_predicate <- function(.fn, ..., .mapper) {
+as_predicate <- function(.fn, ..., .mapper, .na = FALSE) {
   if (.mapper) {
     .fn <- as_mapper(.fn, ...)
   }
@@ -122,7 +122,7 @@ as_predicate <- function(.fn, ..., .mapper) {
   function(...) {
     out <- .fn(...)
 
-    if (!is_bool(out)) {
+    if (!is_bool(out, .na)) {
       abort(sprintf(
         "Predicate functions must return a single logical `TRUE` or `FALSE`, not %s",
         as_predicate_friendly_type_of(out)

--- a/R/as_mapper.R
+++ b/R/as_mapper.R
@@ -113,3 +113,30 @@ plucker <- function(i, default) {
     env = caller_env()
   )
 }
+
+as_predicate <- function(.fn, ..., .mapper) {
+  if (.mapper) {
+    .fn <- as_mapper(.fn, ...)
+  }
+
+  function(...) {
+    out <- .fn(...)
+
+    if (!is_bool(out)) {
+      abort(sprintf(
+        "Predicate functions must return a single logical `TRUE` or `FALSE`, not %s",
+        as_predicate_friendly_type_of(out)
+      ))
+    }
+
+    out
+  }
+}
+
+as_predicate_friendly_type_of <- function(x) {
+  if (is_na(x)) {
+    "a missing value"
+  } else {
+    friendly_type_of(x, length = TRUE)
+  }
+}

--- a/R/cross.R
+++ b/R/cross.R
@@ -116,8 +116,11 @@ cross <- function(.l, .filter = NULL) {
     # NULL elements are removed later on.
     if (!is.null(.filter)) {
       is_to_filter <- do.call(".filter", unname(out[[i]]))
-      if (!is.logical(is_to_filter) || !length(is_to_filter) == 1) {
-        stop("The filter function must return TRUE or FALSE", call. = FALSE)
+      if (!is_bool(is_to_filter)) {
+        abort(sprintf(
+          "The filter function must return a single logical `TRUE` or `FALSE`, not %s",
+          as_predicate_friendly_type_of(is_to_filter)
+        ))
       }
       if (is_to_filter) {
         out[i] <- list(NULL)

--- a/R/detect.R
+++ b/R/detect.R
@@ -43,8 +43,11 @@ detect <- function(.x, .f, ..., .right = FALSE) {
   .f <- as_predicate(.f, ..., .mapper = TRUE)
 
   for (i in index(.x, .right)) {
-    if (is_true(.f(.x[[i]], ...))) return(.x[[i]])
+    if (.f(.x[[i]], ...)) {
+      return(.x[[i]])
+    }
   }
+
   NULL
 }
 
@@ -54,8 +57,11 @@ detect_index <- function(.x, .f, ..., .right = FALSE) {
   .f <- as_predicate(.f, ..., .mapper = TRUE)
 
   for (i in index(.x, .right)) {
-    if (is_true(.f(.x[[i]], ...))) return(i)
+    if (.f(.x[[i]], ...)) {
+      return(i)
+    }
   }
+
   0L
 }
 

--- a/R/detect.R
+++ b/R/detect.R
@@ -40,7 +40,7 @@
 #' # If you need to find all positions, use map_lgl():
 #' which(map_lgl(x, "foo"))
 detect <- function(.x, .f, ..., .right = FALSE) {
-  .f <- as_mapper(.f, ...)
+  .f <- as_predicate(.f, ..., .mapper = TRUE)
 
   for (i in index(.x, .right)) {
     if (is_true(.f(.x[[i]], ...))) return(.x[[i]])
@@ -51,7 +51,7 @@ detect <- function(.x, .f, ..., .right = FALSE) {
 #' @export
 #' @rdname detect
 detect_index <- function(.x, .f, ..., .right = FALSE) {
-  .f <- as_mapper(.f, ...)
+  .f <- as_predicate(.f, ..., .mapper = TRUE)
 
   for (i in index(.x, .right)) {
     if (is_true(.f(.x[[i]], ...))) return(i)

--- a/R/every-some.R
+++ b/R/every-some.R
@@ -9,10 +9,6 @@
 #' @return A logical vector of length 1.
 #' @export
 #' @examples
-#' x <- list(0, 1, TRUE)
-#' x %>% every(identity)
-#' x %>% some(identity)
-#'
 #' y <- list(0:10, 5.5)
 #' y %>% every(is.numeric)
 #' y %>% every(is.integer)

--- a/R/every-some.R
+++ b/R/every-some.R
@@ -17,23 +17,27 @@
 #' y %>% every(is.numeric)
 #' y %>% every(is.integer)
 every <- function(.x, .p, ...) {
-  .p <- as_mapper(.p, ...)
+  .p <- as_predicate(.p, ..., .mapper = TRUE)
+
   for (i in seq_along(.x)) {
     val <- .p(.x[[i]], ...)
     if (is_false(val)) return(FALSE)
     if (anyNA(val)) return(NA)
   }
+
   TRUE
 }
 
 #' @export
 #' @rdname every
 some <- function(.x, .p, ...) {
-  .p <- as_mapper(.p, ...)
+  .p <- as_predicate(.p, ..., .mapper = TRUE)
+
   val <- FALSE
   for (i in seq_along(.x)) {
     val <- val || .p(.x[[i]], ...)
     if (is_true(val)) return(TRUE)
   }
+
   val
 }

--- a/R/every-some.R
+++ b/R/every-some.R
@@ -13,7 +13,7 @@
 #' y %>% every(is.numeric)
 #' y %>% every(is.integer)
 every <- function(.x, .p, ...) {
-  .p <- as_predicate(.p, ..., .mapper = TRUE, .na = NULL)
+  .p <- as_predicate(.p, ..., .mapper = TRUE, .deprecate = TRUE)
 
   for (i in seq_along(.x)) {
     val <- .p(.x[[i]], ...)
@@ -27,7 +27,7 @@ every <- function(.x, .p, ...) {
 #' @export
 #' @rdname every
 some <- function(.x, .p, ...) {
-  .p <- as_predicate(.p, ..., .mapper = TRUE, .na = NULL)
+  .p <- as_predicate(.p, ..., .mapper = TRUE, .deprecate = TRUE)
 
   val <- FALSE
   for (i in seq_along(.x)) {

--- a/R/every-some.R
+++ b/R/every-some.R
@@ -17,7 +17,7 @@
 #' y %>% every(is.numeric)
 #' y %>% every(is.integer)
 every <- function(.x, .p, ...) {
-  .p <- as_predicate(.p, ..., .mapper = TRUE)
+  .p <- as_predicate(.p, ..., .mapper = TRUE, .na = NULL)
 
   for (i in seq_along(.x)) {
     val <- .p(.x[[i]], ...)
@@ -31,7 +31,7 @@ every <- function(.x, .p, ...) {
 #' @export
 #' @rdname every
 some <- function(.x, .p, ...) {
-  .p <- as_predicate(.p, ..., .mapper = TRUE)
+  .p <- as_predicate(.p, ..., .mapper = TRUE, .na = NULL)
 
   val <- FALSE
   for (i in seq_along(.x)) {

--- a/R/modify.R
+++ b/R/modify.R
@@ -348,6 +348,7 @@ probe <- function(.x, .p, ...) {
     stopifnot(length(.p) == length(.x))
     .p
   } else {
+    .p <- as_predicate(.p, ..., .mapper = TRUE)
     map_lgl(.x, .p, ...)
   }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -125,12 +125,18 @@ paste_line <- function(...) {
 }
 
 # From rlang
-friendly_type_of <- function(x) {
+friendly_type_of <- function(x, length = FALSE) {
   if (is.object(x)) {
-    sprintf("a `%s` object", paste_classes(x))
-  } else {
-    as_friendly_type(typeof(x))
+    return(sprintf("a `%s` object", paste_classes(x)))
   }
+
+  friendly <- as_friendly_type(typeof(x))
+
+  if (length && is_vector(x)) {
+    friendly <- paste0(friendly, sprintf(" of length %s", length(x)))
+  }
+
+  friendly
 }
 as_friendly_type <- function(type) {
   switch(type,
@@ -174,4 +180,8 @@ as_friendly_type <- function(type) {
 }
 paste_classes <- function(x) {
   paste(class(x), collapse = "/")
+}
+
+is_bool <- function(x) {
+  is_logical(x, n = 1) && !is.na(x)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -182,6 +182,14 @@ paste_classes <- function(x) {
   paste(class(x), collapse = "/")
 }
 
-is_bool <- function(x) {
-  is_logical(x, n = 1) && !is.na(x)
+is_bool <- function(x, na = NULL) {
+  if (!is_logical(x, n = 1)) {
+    return(FALSE)
+  }
+
+  if (is_null(na)) {
+    return(TRUE)
+  }
+
+  identical(na, is.na(x))
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -182,14 +182,6 @@ paste_classes <- function(x) {
   paste(class(x), collapse = "/")
 }
 
-is_bool <- function(x, na = NULL) {
-  if (!is_logical(x, n = 1)) {
-    return(FALSE)
-  }
-
-  if (is_null(na)) {
-    return(TRUE)
-  }
-
-  identical(na, is.na(x))
+is_bool <- function(x) {
+  is_logical(x, n = 1) && !is.na(x)
 }

--- a/man/every.Rd
+++ b/man/every.Rd
@@ -26,10 +26,6 @@ A logical vector of length 1.
 Do every or some elements of a list satisfy a predicate?
 }
 \examples{
-x <- list(0, 1, TRUE)
-x \%>\% every(identity)
-x \%>\% some(identity)
-
 y <- list(0:10, 5.5)
 y \%>\% every(is.numeric)
 y \%>\% every(is.integer)

--- a/tests/testthat/test-cross.R
+++ b/tests/testthat/test-cross.R
@@ -15,6 +15,10 @@ test_that("filtering works", {
   expect_equal(out, list(list(1, 2), list(1, 3), list(2, 3)))
 })
 
+test_that("filtering requires a predicate function", {
+  expect_error(cross2(1:3, 1:3, .filter = ~ c(TRUE, TRUE)), "not a logical vector of length 2")
+})
+
 test_that("filtering fails when filter function doesn't return a logical", {
   filter <- function(x, y, z) x + y + z
   expect_error(cross3(1:3, 1:3, 1:3, .filter = filter))

--- a/tests/testthat/test-detect.R
+++ b/tests/testthat/test-detect.R
@@ -22,3 +22,8 @@ test_that("has_element checks whether a list contains an object", {
   expect_true(has_element(list(1, 2), 1))
   expect_false(has_element(list(1, 2), 3))
 })
+
+test_that("`detect()` requires a predicate function", {
+  expect_error(detect(list(1:2, 2), is.na), "must return a single logical")
+  expect_error(detect(list(1:2, 2), function(...) NA), "not a missing value")
+})

--- a/tests/testthat/test-every-some.R
+++ b/tests/testthat/test-every-some.R
@@ -16,3 +16,8 @@ test_that("some returns FALSE if all elements are FALSE", {
   expect_false(some(x, isTRUE))
   expect_true(some(x[1], negate(isTRUE)))
 })
+
+test_that("every and some require predicate functions", {
+  expect_error(some(1:3, ~ NA), ", not a missing value")
+  expect_error(every(1:3, ~ c(TRUE, FALSE)), ", not a logical vector of length 2")
+})

--- a/tests/testthat/test-every-some.R
+++ b/tests/testthat/test-every-some.R
@@ -1,10 +1,5 @@
 context("every-some")
 
-test_that("return NA if present", {
-  expect_equal(some(1:10, ~ NA), NA)
-  expect_equal(every(1:10, ~ NA), NA)
-})
-
 test_that("every returns TRUE if all elements are TRUE", {
   x <- list(0, 1, TRUE)
   expect_false(every(x, isTRUE))
@@ -15,4 +10,13 @@ test_that("some returns FALSE if all elements are FALSE", {
   x <- list(1, 0, FALSE)
   expect_false(some(x, isTRUE))
   expect_true(some(x[1], negate(isTRUE)))
+})
+
+
+# Life cycle --------------------------------------------------------------
+
+test_that("return NA if present", {
+  scoped_lifecycle_warnings()
+  expect_warning(expect_equal(some(1:10, ~ NA), NA), "soft-deprecated")
+  expect_warning(expect_equal(every(1:10, ~ NA), NA), "soft-deprecated")
 })

--- a/tests/testthat/test-every-some.R
+++ b/tests/testthat/test-every-some.R
@@ -16,8 +16,3 @@ test_that("some returns FALSE if all elements are FALSE", {
   expect_false(some(x, isTRUE))
   expect_true(some(x[1], negate(isTRUE)))
 })
-
-test_that("every and some require predicate functions", {
-  expect_error(some(1:3, ~ NA), ", not a missing value")
-  expect_error(every(1:3, ~ c(TRUE, FALSE)), ", not a logical vector of length 2")
-})

--- a/tests/testthat/test-head-tail.R
+++ b/tests/testthat/test-head-tail.R
@@ -14,3 +14,8 @@ test_that("original vector returned if predicate satisfied by all elements", {
   expect_identical(head_while(y, function(x) x <= 100), y)
   expect_identical(tail_while(y, function(x) x >= 0), y)
 })
+
+test_that("head_while and tail_while require predicate function", {
+  expect_error(head_while(1:3, ~ NA), ", not a missing value")
+  expect_error(tail_while(1:3, ~ c(TRUE, FALSE)), ", not a logical vector of length 2")
+})

--- a/tests/testthat/test-map.R
+++ b/tests/testthat/test-map.R
@@ -100,3 +100,7 @@ test_that("primitive dispatch correctly", {
   x <- structure(list(), class = "test_class")
   expect_identical(map(list(x, x), as.character), list("dispatched!", "dispatched!"))
 })
+
+test_that("map_if requires predicate functions", {
+  expect_error(map_if(1:3, ~ NA, ~ "foo"), ", not a missing value")
+})

--- a/tests/testthat/test-modify.R
+++ b/tests/testthat/test-modify.R
@@ -81,6 +81,11 @@ test_that("modify2() recycles arguments", {
   expect_identical(modify2(mtcars, 1, `+`)$carb, mtcars$carb + 1L)
 })
 
+test_that("modify_if() requires predicate functions", {
+  expect_error(modify_if(list(1, 2), ~ NA, ~ "foo"), ", not a missing value")
+  expect_error(modify_if(1:2, ~ c(TRUE, FALSE), ~ "foo"), ", not a logical vector of length 2")
+})
+
 # modify_depth ------------------------------------------------------------
 
 test_that("modify_depth modifies values at specified depth", {

--- a/tests/testthat/test-predicates.R
+++ b/tests/testthat/test-predicates.R
@@ -12,3 +12,8 @@ test_that("predicate-based functionals work with logical vectors", {
     list("1", 2, "3")
   )
 })
+
+test_that("keep() and discard() require predicate functions", {
+  expect_error(keep(1:3, ~ NA), ", not a missing value")
+  expect_error(discard(1:3, ~ 1:3), ", not an integer vector of length 3")
+})


### PR DESCRIPTION
Closes #470.

`keep()`, `map_if()`, and variants now fail with an informative error message when the predicate function dose not return `TRUE` or `FALSE`.

This is only soft-deprecated for `every()` and `some()` as they were documented to have liberal truthness. Also the unit tests check that these functions return `NA` when the predicate has returned `NA`. I think it's best to deprecate this behaviour for consistency with predicate-based functionals within purrr, and because it simplifies the type of these functions (you can count on them returning TRUE/FALSE, missing values have to be dealt beforehand to avoid an early error).