### PR TITLE
Fix `modify_depth()` with atomic vectors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -81,6 +81,9 @@ reduce2_right(.x = letters[1:4], .y = paste2, .f = c("-", ".", "-")) # working
 
 ## Minor improvements and fixes
 
+* `modify_depth()` now modifies atomic leaves as well. This makes
+  `modify_depth(x, 1, fn)` equivalent to `modify(x, fn)` (#359).
+
 * `compose()` now returns an identity function when called without
   inputs.
 

--- a/man/modify.Rd
+++ b/man/modify.Rd
@@ -79,9 +79,9 @@ be recycled.}
 \item{.depth}{Level of \code{.x} to map on. Use a negative value to count up
 from the lowest level of the list.
 \itemize{
-\item \code{modify_depth(x, 0, fun)} is equivalent to \code{x[] <- fun(x)}
-\item \code{modify_depth(x, 1, fun)} is equivalent to \code{x[] <- map(x, fun)}
-\item \code{modify_depth(x, 2, fun)} is equivalent to \code{x[] <- map(x, ~ map(., fun))}
+\item \code{modify_depth(x, 0, fun)} is equivalent to \code{x[] <- fun(x)}.
+\item \code{modify_depth(x, 1, fun)} is equivalent to \code{x <- modify(x, fun)}
+\item \code{modify_depth(x, 2, fun)} is equivalent to \code{x <- modify(x, ~ modify(., fun))}
 }}
 
 \item{.ragged}{If \code{TRUE}, will apply to leaves, even if they're not
@@ -176,6 +176,13 @@ l1 <- list(
 # In the above list, "obj" is level 1, "prop" is level 2 and "param"
 # is level 3. To apply sum() on all params, we map it at depth 3:
 l1 \%>\% modify_depth(3, sum) \%>\% str()
+
+# Note that vectorised operations will yield the same result when
+# applied at the list level as when applied at the atomic result.
+# The former is more efficient because it takes advantage of
+# vectorisation.
+l1 \%>\% modify_depth(3, `+`, 100L)
+l1 \%>\% modify_depth(4, `+`, 100L)
 
 # modify() lets us pluck the elements prop1/param2 in obj1 and obj2:
 l1 \%>\% modify(c("prop1", "param2")) \%>\% str()

--- a/tests/testthat/test-modify.R
+++ b/tests/testthat/test-modify.R
@@ -95,14 +95,16 @@ test_that("`.else` modifies false elements", {
 # modify_depth ------------------------------------------------------------
 
 test_that("modify_depth modifies values at specified depth", {
-  x1 <- list(list(list(1)))
+  x1 <- list(list(list(1:3, 4:6)))
 
   expect_equal(modify_depth(x1, 0, length), list(1))
   expect_equal(modify_depth(x1, 1, length), list(1))
-  expect_equal(modify_depth(x1, 2, length), list(list(1)))
-  expect_equal(modify_depth(x1, 3, length), list(list(list(1))))
-  expect_equal(modify_depth(x1, -1, length), list(list(list(1))))
-  expect_error(modify_depth(x1, 4, length), "List not deep enough")
+  expect_equal(modify_depth(x1, 2, length), list(list(2)))
+  expect_equal(modify_depth(x1, 3, length), list(list(list(3, 3))))
+  expect_equal(modify_depth(x1, -1, length), list(list(list(3, 3))))
+  expect_equal(modify_depth(x1, 4, length), list(list(list(c(1, 1, 1), c(1, 1, 1)))))
+  expect_error(modify_depth(x1, 5, length), "List not deep enough")
+  expect_error(modify_depth(x1, 6, length), "List not deep enough")
   expect_error(modify_depth(x1, -5, length), "Invalid depth")
 })
 
@@ -120,4 +122,12 @@ test_that(".ragged = TRUE operates on leaves", {
   expect_equal(modify_depth(x1, -1, ~ . + 1, .ragged = TRUE), x2)
   # .ragged should be TRUE is .depth < 0
   expect_equal(modify_depth(x1, -1, ~ . + 1), x2)
+})
+
+test_that("vectorised operations on the recursive and atomic levels yield same results", {
+  x <- list(list(list(1:3, 4:6)))
+  exp <- list(list(list(11:13, 14:16)))
+  expect_identical(modify_depth(x, 3, `+`, 10L), exp)
+  expect_identical(modify_depth(x, 4, `+`, 10L), exp)
+  expect_error(modify_depth(x, 5, `+`, 10L), "not deep enough")
 })

--- a/tests/testthat/test-modify.R
+++ b/tests/testthat/test-modify.R
@@ -103,7 +103,7 @@ test_that("modify_depth modifies values at specified depth", {
   expect_equal(modify_depth(x1, 3, length), list(list(list(1))))
   expect_equal(modify_depth(x1, -1, length), list(list(list(1))))
   expect_error(modify_depth(x1, 4, length), "List not deep enough")
-  expect_error(modify_depth(x1, -5, length), "Invalid `depth`")
+  expect_error(modify_depth(x1, -5, length), "Invalid depth")
 })
 
 test_that(".ragged = TRUE operates on leaves", {


### PR DESCRIPTION
With this change, `modify_depth()` also modifies atomic vectors, so that `modify_depth(x, 1, f) === modify(x, f)`. Also uses `modify()` rather than `x[] <- map()` for consistency with modify implementations.

Closes #359.

This can be a little confusing with vectorised operations because they yield the same result when applied at the surrounding list level than at the atomic vector level. The former is more efficient because of vectorisation. This subtlety is explored in a new example.