### PR TITLE
Add error conditions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -81,6 +81,8 @@ reduce2_right(.x = letters[1:4], .y = paste2, .f = c("-", ".", "-")) # working
 
 ## Minor improvements and fixes
 
+* `flatten()` now supports raw and complex elements.
+
 * By popular request, `at_depth()` has been brought back as
   `map_depth()`. Like `modify_depth()`, it applies a function at a
   specified level of a data structure. However, it transforms all

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -23,7 +23,7 @@
 #' packages might tweak the friendly representation at any time.
 #'
 #' @keywords internal
-#' @name purrr-conditions
+#' @name purrr-conditions-type
 #' @noRd
 NULL
 
@@ -99,4 +99,79 @@ what_bad_element <- function(what, arg, index) {
 
   what <- what %||% "Element"
   sprintf("%s %d%s", what, index, where)
+}
+
+
+#' Error conditions for bad lengths
+#'
+#' @inheritParams purrr-conditions-type
+#' @param actual,expected The expected and actual lengths. If `actual`
+#'   is not supplied, `length(x)` is taken as default.
+#' @param recycle Whether `x` is also allowed to have length 1.
+#'
+#' @name purrr-conditions-length
+NULL
+
+stop_bad_length <- function(x,
+                            expected,
+                            ...,
+                            actual = NULL,
+                            what = NULL,
+                            arg = NULL,
+                            message = NULL,
+                            .recycle = FALSE,
+                            .subclass = NULL) {
+  what <- what %||% what_bad_object(arg) %||% "Vector"
+  actual <- actual %||% length(x)
+
+  if (.recycle) {
+    expected <- sprintf("1 or %s", expected)
+  }
+
+  message <- message %||% sprintf("%s must have length %s, not %s", what, expected, actual)
+
+  if (!is_integerish(actual)) {
+    stop_bad_type(actual, "a single number", arg = "`actual`")
+  }
+  if (length(actual) != 1) {
+    stop_bad_length(actual, 1, arg = "`actual`")
+  }
+
+  abort(
+    message,
+    x = x,
+    expected = expected,
+    actual = actual,
+    what = what,
+    arg = arg,
+    ...,
+    .subclass = c(.subclass, "purrr_error_bad_length")
+  )
+}
+
+stop_bad_element_length <- function(x,
+                                    index,
+                                    expected,
+                                    ...,
+                                    actual = NULL,
+                                    what = NULL,
+                                    arg = NULL,
+                                    message = NULL,
+                                    .recycle = FALSE,
+                                    .subclass = NULL) {
+  stopifnot(is_integerish(index, n = 1, finite = TRUE))
+  what <- what_bad_element(what, arg, index)
+
+  stop_bad_length(
+    x,
+    expected,
+    actual = actual,
+    what = what,
+    arg = arg,
+    index = index,
+    ...,
+    message = message,
+    .recycle = .recycle,
+    .subclass = c(.subclass, "purrr_error_bad_element_length")
+  )
 }

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -105,43 +105,43 @@ what_bad_element <- function(what, arg, index) {
 #' Error conditions for bad lengths
 #'
 #' @inheritParams purrr-conditions-type
-#' @param actual,expected The expected and actual lengths. If `actual`
-#'   is not supplied, `length(x)` is taken as default.
-#' @param recycle Whether `x` is also allowed to have length 1.
+#' @param expected_length The expected length as a number. The actual length
+#'   is computed with `length(x)`.
+#' @param .recycle Whether `x` is also allowed to have length 1.
 #'
+#' @keywords internal
 #' @name purrr-conditions-length
+#' @noRd
 NULL
 
 stop_bad_length <- function(x,
-                            expected,
+                            expected_length,
                             ...,
-                            actual = NULL,
                             what = NULL,
                             arg = NULL,
                             message = NULL,
                             .recycle = FALSE,
                             .subclass = NULL) {
   what <- what %||% what_bad_object(arg) %||% "Vector"
-  actual <- actual %||% length(x)
 
   if (.recycle) {
-    expected <- sprintf("1 or %s", expected)
+    expected <- sprintf("1 or %s", expected_length)
+  } else {
+    expected <- as.character(expected_length)
   }
+  actual <- length(x)
 
-  message <- message %||% sprintf("%s must have length %s, not %s", what, expected, actual)
-
-  if (!is_integerish(actual)) {
-    stop_bad_type(actual, "a single number", arg = "`actual`")
-  }
-  if (length(actual) != 1) {
-    stop_bad_length(actual, 1, arg = "`actual`")
-  }
+  message <- message %||% sprintf(
+    "%s must have length %s, not %s",
+    what,
+    expected,
+    actual
+  )
 
   abort(
     message,
     x = x,
-    expected = expected,
-    actual = actual,
+    expected_length = expected_length,
     what = what,
     arg = arg,
     ...,
@@ -151,9 +151,8 @@ stop_bad_length <- function(x,
 
 stop_bad_element_length <- function(x,
                                     index,
-                                    expected,
+                                    expected_length,
                                     ...,
-                                    actual = NULL,
                                     what = NULL,
                                     arg = NULL,
                                     message = NULL,
@@ -164,8 +163,7 @@ stop_bad_element_length <- function(x,
 
   stop_bad_length(
     x,
-    expected,
-    actual = actual,
+    expected_length,
     what = what,
     arg = arg,
     index = index,

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -2,9 +2,9 @@
 #'
 #' @param x The object whose type doesn't match `expected`.
 #' @param what What does `x` represent? This is used to introduce the
-#'   object in the error message. If `NULL` and `arg` is `NULL` as
-#'   well, defaults to `"Object"`. Otherwise defaults to `arg` wrapped
-#'   in backquotes.
+#'   object in the error message and should be capitalised. If `NULL`
+#'   and `arg` is `NULL` as well, defaults to `"Object"`. Otherwise
+#'   defaults to `arg` wrapped in backquotes.
 #' @param expected,actual The expected and actual type of `x`, in
 #'   friendly representation. If `actual` is not supplied, `x` is
 #'   passed to `friendly_type_of()` to provide a default value.
@@ -55,9 +55,9 @@ stop_bad_type <- function(x,
   abort(
     message,
     x = x,
-    what = what,
     expected = expected,
     actual = actual,
+    what = what,
     arg = arg,
     ...,
     .subclass = c(.subclass, "purrr_error_bad_type")
@@ -69,6 +69,7 @@ stop_bad_element_type <- function(x,
                                   expected,
                                   ...,
                                   actual = NULL,
+                                  what = NULL,
                                   arg = NULL,
                                   message = NULL,
                                   .subclass = NULL) {
@@ -79,13 +80,14 @@ stop_bad_element_type <- function(x,
   } else {
     where <- sprintf(" of `%s`", as_string(arg))
   }
-  what <- sprintf("Element %d%s", index, where)
+  what <- what %||% "Element"
+  what <- sprintf("%s %d%s", what, index, where)
 
   stop_bad_type(
     x,
     expected,
-    what = what,
     actual = actual,
+    what = what,
     arg = arg,
     index = index,
     ...,

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -107,7 +107,7 @@ what_bad_element <- function(what, arg, index) {
 #' @inheritParams purrr-conditions-type
 #' @param expected_length The expected length as a number. The actual length
 #'   is computed with `length(x)`.
-#' @param .recycle Whether `x` is also allowed to have length 1.
+#' @param recycle Whether `x` is also allowed to have length 1.
 #'
 #' @keywords internal
 #' @name purrr-conditions-length
@@ -120,11 +120,11 @@ stop_bad_length <- function(x,
                             what = NULL,
                             arg = NULL,
                             message = NULL,
-                            .recycle = FALSE,
+                            recycle = FALSE,
                             .subclass = NULL) {
   what <- what %||% what_bad_object(arg) %||% "Vector"
 
-  if (.recycle) {
+  if (recycle) {
     expected <- sprintf("1 or %s", expected_length)
   } else {
     expected <- as.character(expected_length)
@@ -144,6 +144,7 @@ stop_bad_length <- function(x,
     expected_length = expected_length,
     what = what,
     arg = arg,
+    recycle = recycle,
     ...,
     .subclass = c(.subclass, "purrr_error_bad_length")
   )
@@ -156,7 +157,7 @@ stop_bad_element_length <- function(x,
                                     what = NULL,
                                     arg = NULL,
                                     message = NULL,
-                                    .recycle = FALSE,
+                                    recycle = FALSE,
                                     .subclass = NULL) {
   stopifnot(is_integerish(index, n = 1, finite = TRUE))
   what <- what_bad_element(what, arg, index)
@@ -168,8 +169,8 @@ stop_bad_element_length <- function(x,
     arg = arg,
     index = index,
     ...,
+    recycle = recycle,
     message = message,
-    .recycle = .recycle,
     .subclass = c(.subclass, "purrr_error_bad_element_length")
   )
 }
@@ -190,11 +191,11 @@ stop_bad_vector <- function(x,
                             what = NULL,
                             arg = NULL,
                             message = NULL,
-                            .recycle = FALSE,
+                            recycle = FALSE,
                             .subclass = NULL) {
   what <- what %||% what_bad_object(arg) %||% "Vector"
 
-  expected <- friendly_vector_type(expected_ptype, expected_length, .recycle)
+  expected <- friendly_vector_type(expected_ptype, expected_length, recycle)
   actual <- friendly_vector_type(x, length(x))
 
   stop_bad_type(
@@ -203,6 +204,7 @@ stop_bad_vector <- function(x,
     actual = actual,
     what = what,
     arg = arg,
+    recycle = recycle,
     message = message,
     .subclass = c(.subclass, "purrr_error_bad_vector")
   )
@@ -216,7 +218,7 @@ stop_bad_element_vector <- function(x,
                                     what = NULL,
                                     arg = NULL,
                                     message = NULL,
-                                    .recycle = FALSE,
+                                    recycle = FALSE,
                                     .subclass = NULL) {
   stopifnot(is_integerish(index, n = 1, finite = TRUE))
   what <- what_bad_element(what, arg, index)
@@ -229,8 +231,8 @@ stop_bad_element_vector <- function(x,
     arg = arg,
     index = index,
     ...,
+    recycle = recycle,
     message = message,
-    .recycle = .recycle,
     .subclass = c(.subclass, "purrr_error_bad_element_vector")
   )
 }

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -2,7 +2,9 @@
 #'
 #' @param x The object whose type doesn't match `expected`.
 #' @param what What does `x` represent? This is used to introduce the
-#'   object in the error message.
+#'   object in the error message. If `NULL` and `arg` is `NULL` as
+#'   well, defaults to `"Object"`. Otherwise defaults to `arg` wrapped
+#'   in backquotes.
 #' @param expected,actual The expected and actual type of `x`, in
 #'   friendly representation. If `actual` is not supplied, `x` is
 #'   passed to `friendly_type_of()` to provide a default value.
@@ -28,10 +30,20 @@ NULL
 stop_bad_type <- function(x,
                           expected,
                           ...,
-                          what = "Object",
                           actual = NULL,
+                          what = NULL,
+                          arg = NULL,
                           message = NULL,
                           .subclass = NULL) {
+  if (is_null(what)) {
+    if (is_null(arg)) {
+      what <- "Object"
+    } else if (is_string(arg)) {
+      what <- sprintf("`%s`", arg)
+    } else {
+      stop_bad_type(arg, "`NULL` or a string", arg = "arg")
+    }
+  }
   actual <- actual %||% friendly_type_of(x)
   message <- message %||% sprintf(
     "%s must be %s, not %s",
@@ -46,6 +58,7 @@ stop_bad_type <- function(x,
     what = what,
     expected = expected,
     actual = actual,
+    arg = arg,
     ...,
     .subclass = c(.subclass, "purrr_error_bad_type")
   )

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -241,7 +241,7 @@ friendly_vector_type <- function(x, length = NULL, recycle = FALSE) {
   length <- length %||% length(x)
 
   if (length == 1) {
-    return(friendly_element_type_of(x))
+    return(friendly_type_of_element(x))
   }
 
   if (is.object(x)) {

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -35,15 +35,7 @@ stop_bad_type <- function(x,
                           arg = NULL,
                           message = NULL,
                           .subclass = NULL) {
-  if (is_null(what)) {
-    if (is_null(arg)) {
-      what <- "Object"
-    } else if (is_string(arg)) {
-      what <- sprintf("`%s`", arg)
-    } else {
-      stop_bad_type(arg, "`NULL` or a string", arg = "arg")
-    }
-  }
+  what <- what %||% what_bad_object(arg) %||% "Object"
   actual <- actual %||% friendly_type_of(x)
   message <- message %||% sprintf(
     "%s must be %s, not %s",
@@ -74,14 +66,7 @@ stop_bad_element_type <- function(x,
                                   message = NULL,
                                   .subclass = NULL) {
   stopifnot(is_integerish(index, n = 1, finite = TRUE))
-
-  if (is_null(arg)) {
-    where <- ""
-  } else {
-    where <- sprintf(" of `%s`", as_string(arg))
-  }
-  what <- what %||% "Element"
-  what <- sprintf("%s %d%s", what, index, where)
+  what <- what_bad_element(what, arg, index)
 
   stop_bad_type(
     x,
@@ -94,4 +79,24 @@ stop_bad_element_type <- function(x,
     message = message,
     .subclass = c(.subclass, "purrr_error_bad_element_type")
   )
+}
+
+what_bad_object <- function(arg) {
+  if (is_null(arg)) {
+    NULL
+  } else if (is_string(arg)) {
+    sprintf("`%s`", arg)
+  } else {
+    stop_bad_type(arg, "`NULL` or a string", arg = "arg")
+  }
+}
+what_bad_element <- function(what, arg, index) {
+  if (is_null(arg)) {
+    where <- ""
+  } else {
+    where <- sprintf(" of `%s`", as_string(arg))
+  }
+
+  what <- what %||% "Element"
+  sprintf("%s %d%s", what, index, where)
 }

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -173,3 +173,87 @@ stop_bad_element_length <- function(x,
     .subclass = c(.subclass, "purrr_error_bad_element_length")
   )
 }
+
+#' Error conditions for bad vectors
+#'
+#' @inheritParams purrr-conditions-length
+#' @param expected_ptype The expected prototype of `x`, i.e. an empty
+#'   vector of the expected type.
+#'
+#' @keywords internal
+#' @name purrr-conditions-vector
+#' @noRd
+stop_bad_vector <- function(x,
+                            expected_ptype,
+                            expected_length = NULL,
+                            ...,
+                            what = NULL,
+                            arg = NULL,
+                            message = NULL,
+                            .recycle = FALSE,
+                            .subclass = NULL) {
+  what <- what %||% what_bad_object(arg) %||% "Vector"
+
+  expected <- friendly_vector_type(expected_ptype, expected_length, .recycle)
+  actual <- friendly_vector_type(x, length(x))
+
+  stop_bad_type(
+    x,
+    expected,
+    actual = actual,
+    what = what,
+    arg = arg,
+    message = message,
+    .subclass = c(.subclass, "purrr_error_bad_vector")
+  )
+}
+
+stop_bad_element_vector <- function(x,
+                                    index,
+                                    expected_ptype,
+                                    expected_length,
+                                    ...,
+                                    what = NULL,
+                                    arg = NULL,
+                                    message = NULL,
+                                    .recycle = FALSE,
+                                    .subclass = NULL) {
+  stopifnot(is_integerish(index, n = 1, finite = TRUE))
+  what <- what_bad_element(what, arg, index)
+
+  stop_bad_vector(
+    x,
+    expected_ptype,
+    expected_length,
+    what = what,
+    arg = arg,
+    index = index,
+    ...,
+    message = message,
+    .recycle = .recycle,
+    .subclass = c(.subclass, "purrr_error_bad_element_vector")
+  )
+}
+
+friendly_vector_type <- function(x, length = NULL, recycle = FALSE) {
+  length <- length %||% length(x)
+
+  if (length == 1) {
+    return(friendly_element_type_of(x, single = TRUE))
+  }
+
+  if (is.object(x)) {
+    classes <- paste0("`", paste_classes(x), "`")
+    type <- sprintf("a vector of class %s and", classes)
+  } else {
+    type <- friendly_type_of(x)
+  }
+
+  if (recycle) {
+    length <- sprintf("1 or %s", length)
+  } else {
+    length <- as.character(length)
+  }
+
+  sprintf("%s of length %s", type, length)
+}

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -1,0 +1,82 @@
+#' Error conditions for bad types
+#'
+#' @param x The object whose type doesn't match `expected`.
+#' @param what What does `x` represent? This is used to introduce the
+#'   object in the error message.
+#' @param expected,actual The expected and actual type of `x`, in
+#'   friendly representation. If `actual` is not supplied, `x` is
+#'   passed to `friendly_type_of()` to provide a default value.
+#' @param index The index of `x` when it is an element of a vector.
+#' @param ...,message,.subclass Only use these fields when creating a subclass.
+#'
+#' @details
+#'
+#' Some of the fields are expected to be in friendly representation,
+#' i.e. a longer description that includes indefinite articles. For
+#' example, a friendly representation of `"integer"` would be
+#' `"an integer vector"`.
+#'
+#' Fields in pretty representation are meant for printing, not for
+#' testing. They should not be relied on in unit tests as upstream
+#' packages might tweak the friendly representation at any time.
+#'
+#' @keywords internal
+#' @name purrr-conditions
+#' @noRd
+NULL
+
+stop_bad_type <- function(x,
+                          expected,
+                          ...,
+                          what = "Object",
+                          actual = NULL,
+                          message = NULL,
+                          .subclass = NULL) {
+  actual <- actual %||% friendly_type_of(x)
+  message <- message %||% sprintf(
+    "%s must be %s, not %s",
+    what,
+    expected,
+    actual
+  )
+
+  abort(
+    message,
+    x = x,
+    what = what,
+    expected = expected,
+    actual = actual,
+    ...,
+    .subclass = c(.subclass, "purrr_error_bad_type")
+  )
+}
+
+stop_bad_element_type <- function(x,
+                                  index,
+                                  expected,
+                                  ...,
+                                  actual = NULL,
+                                  arg = NULL,
+                                  message = NULL,
+                                  .subclass = NULL) {
+  stopifnot(is_integerish(index, n = 1, finite = TRUE))
+
+  if (is_null(arg)) {
+    where <- ""
+  } else {
+    where <- sprintf(" of `%s`", as_string(arg))
+  }
+  what <- sprintf("Element %d%s", index, where)
+
+  stop_bad_type(
+    x,
+    expected,
+    what = what,
+    actual = actual,
+    arg = arg,
+    index = index,
+    ...,
+    message = message,
+    .subclass = c(.subclass, "purrr_error_bad_element_type")
+  )
+}

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -239,7 +239,7 @@ friendly_vector_type <- function(x, length = NULL, recycle = FALSE) {
   length <- length %||% length(x)
 
   if (length == 1) {
-    return(friendly_element_type_of(x, single = TRUE))
+    return(friendly_element_type_of(x))
   }
 
   if (is.object(x)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -186,7 +186,7 @@ is_bool <- function(x) {
   is_logical(x, n = 1) && !is.na(x)
 }
 
-friendly_element_type_of <- function(x) {
+friendly_type_of_element <- function(x) {
   if (is.object(x)) {
     classes <- paste0("`", paste_classes(x), "`")
     if (single) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -186,7 +186,7 @@ is_bool <- function(x) {
   is_logical(x, n = 1) && !is.na(x)
 }
 
-friendly_element_type_of <- function(x, single = FALSE) {
+friendly_element_type_of <- function(x) {
   if (is.object(x)) {
     classes <- paste0("`", paste_classes(x), "`")
     if (single) {
@@ -198,13 +198,13 @@ friendly_element_type_of <- function(x, single = FALSE) {
   }
 
   switch(typeof(x),
-    logical   = if (single) "a single logical"        else "a logical element",
-    integer   = if (single) "a single integer"        else "an integer element",
-    double    = if (single) "a single double"         else "a double element",
-    complex   = if (single) "a single complex number" else "a complex number",
-    character = if (single) "a single string"         else "a character vector element",
-    raw       = if (single) "a single raw value"      else "a raw vector element",
-    list      = if (single) "a single list element"   else "a list element",
+    logical   = "a single logical",
+    integer   = "a single integer",
+    double    = "a single double",
+    complex   = "a single complex number",
+    character = "a single string",
+    raw       = "a single raw value",
+    list      = "a list of one element",
     abort("Expected a base vector type")
   )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -185,3 +185,26 @@ paste_classes <- function(x) {
 is_bool <- function(x) {
   is_logical(x, n = 1) && !is.na(x)
 }
+
+friendly_element_type_of <- function(x, single = FALSE) {
+  if (is.object(x)) {
+    classes <- paste0("`", paste_classes(x), "`")
+    if (single) {
+      friendly <- sprintf("a single %s element", classes)
+    } else {
+      friendly <- sprintf("a %s element", classes)
+    }
+    return(friendly)
+  }
+
+  switch(typeof(x),
+    logical   = if (single) "a single logical"        else "a logical element",
+    integer   = if (single) "a single integer"        else "an integer element",
+    double    = if (single) "a single double"         else "a double element",
+    complex   = if (single) "a single complex number" else "a complex number",
+    character = if (single) "a single string"         else "a character vector element",
+    raw       = if (single) "a single raw value"      else "a raw vector element",
+    list      = if (single) "a single list element"   else "a list element",
+    abort("Expected a base vector type")
+  )
+}

--- a/src/conditions.c
+++ b/src/conditions.c
@@ -48,3 +48,63 @@ void stop_bad_element_type(SEXP x, R_xlen_t index, const char* expected, const c
   Rf_eval(call, R_BaseEnv);
   Rf_error("Internal error: `stop_bad_element_type()` should have thrown earlier");
 }
+
+void stop_bad_length(SEXP x,
+                     R_xlen_t expected,
+                     const char* what,
+                     const char* arg,
+                     bool recycle) {
+  SEXP fn = Rf_lang3(Rf_install(":::"),
+                     Rf_install("purrr"),
+                     Rf_install("stop_bad_length"));
+
+  SEXP call = Rf_lang5(PROTECT(fn),
+                       PROTECT(sym_protect(x)),
+                       PROTECT(Rf_ScalarReal(expected)),
+                       what ? PROTECT(Rf_mkString(what)) : R_NilValue,
+                       arg ? PROTECT(Rf_mkString(arg)) : R_NilValue);
+
+  PROTECT(call);
+
+  SEXP node = CDR(CDR(CDR(call)));
+  SET_TAG(node, Rf_install("what"));
+
+  node = CDR(node);
+  SET_TAG(node, Rf_install("arg"));
+
+  Rf_eval(call, R_BaseEnv);
+  Rf_error("Internal error: `stop_bad_length()` should have thrown earlier");
+}
+
+void stop_bad_element_length(SEXP x,
+                             R_xlen_t index,
+                             R_xlen_t expected,
+                             const char* what,
+                             const char* arg,
+                             bool recycle) {
+  SEXP fn = Rf_lang3(Rf_install(":::"),
+                     Rf_install("purrr"),
+                     Rf_install("stop_bad_element_length"));
+
+  SEXP call = lang7(PROTECT(fn),
+                    PROTECT(sym_protect(x)),
+                    PROTECT(Rf_ScalarReal(index)),
+                    PROTECT(Rf_ScalarReal(expected)),
+                    what ? PROTECT(Rf_mkString(what)) : R_NilValue,
+                    arg ? PROTECT(Rf_mkString(arg)) : R_NilValue,
+                    PROTECT(Rf_ScalarLogical(recycle)));
+
+  PROTECT(call);
+
+  SEXP node = CDR(CDR(CDR(CDR(call))));
+  SET_TAG(node, Rf_install("what"));
+
+  node = CDR(node);
+  SET_TAG(node, Rf_install("arg"));
+
+  node = CDR(node);
+  SET_TAG(node, Rf_install(".recycle"));
+
+  Rf_eval(call, R_BaseEnv);
+  Rf_error("Internal error: `stop_bad_element_length()` should have thrown earlier");
+}

--- a/src/conditions.c
+++ b/src/conditions.c
@@ -1,0 +1,44 @@
+#define R_NO_REMAP
+#include <Rinternals.h>
+#include "utils.h"
+
+void stop_bad_type(SEXP x, const char* expected, const char* what, const char* arg) {
+  SEXP fn = Rf_lang3(Rf_install(":::"),
+                     Rf_install("purrr"),
+                     Rf_install("stop_bad_type"));
+
+  SEXP call = Rf_lang5(PROTECT(fn),
+                       PROTECT(sym_protect(x)),
+                       PROTECT(Rf_mkString(expected)),
+                       what ? PROTECT(Rf_mkString(what)) : R_NilValue,
+                       arg ? PROTECT(Rf_mkString(arg)) : R_NilValue);
+
+  PROTECT(call);
+
+  SEXP node = CDR(CDR(CDR(call)));
+  SET_TAG(node, Rf_install("what"));
+
+  node = CDR(node);
+  SET_TAG(node, Rf_install("arg"));
+
+  Rf_eval(call, R_BaseEnv);
+  Rf_error("Internal error: `stop_bad_type()` should have thrown earlier");
+}
+
+void stop_bad_element_type(SEXP x, int index, const char* expected, const char* arg) {
+  SEXP fn = Rf_lang3(Rf_install(":::"),
+                     Rf_install("purrr"),
+                     Rf_install("stop_bad_element_type"));
+
+  SEXP call = Rf_lang5(PROTECT(fn),
+                       PROTECT(sym_protect(x)),
+                       PROTECT(Rf_ScalarInteger(index)),
+                       PROTECT(Rf_mkString(expected)),
+                       arg ? PROTECT(Rf_mkString(arg)) : R_NilValue);
+
+  PROTECT(call);
+  SET_TAG(CDR(CDR(CDR(CDR(call)))), Rf_install("arg"));
+
+  Rf_eval(call, R_BaseEnv);
+  Rf_error("Internal error: `stop_bad_element_type()` should have thrown earlier");
+}

--- a/src/conditions.c
+++ b/src/conditions.c
@@ -103,7 +103,7 @@ void stop_bad_element_length(SEXP x,
   SET_TAG(node, Rf_install("arg"));
 
   node = CDR(node);
-  SET_TAG(node, Rf_install(".recycle"));
+  SET_TAG(node, Rf_install("recycle"));
 
   Rf_eval(call, R_BaseEnv);
   Rf_error("Internal error: `stop_bad_element_length()` should have thrown earlier");
@@ -167,7 +167,7 @@ void stop_bad_element_vector(SEXP x,
   SET_TAG(node, Rf_install("arg"));
 
   node = CDR(node);
-  SET_TAG(node, Rf_install(".recycle"));
+  SET_TAG(node, Rf_install("recycle"));
 
   Rf_eval(call, R_BaseEnv);
   Rf_error("Internal error: `stop_bad_element_length()` should have thrown earlier");

--- a/src/conditions.c
+++ b/src/conditions.c
@@ -108,3 +108,67 @@ void stop_bad_element_length(SEXP x,
   Rf_eval(call, R_BaseEnv);
   Rf_error("Internal error: `stop_bad_element_length()` should have thrown earlier");
 }
+
+void stop_bad_vector(SEXP x,
+                     SEXP expected_ptype,
+                     R_xlen_t expected_length,
+                     const char* what,
+                     const char* arg,
+                     bool recycle) {
+  SEXP fn = Rf_lang3(Rf_install(":::"),
+                     Rf_install("purrr"),
+                     Rf_install("stop_bad_vector"));
+
+  SEXP call = Rf_lang6(PROTECT(fn),
+                       x,
+                       expected_ptype,
+                       PROTECT(Rf_ScalarReal(expected_length)),
+                       what ? PROTECT(Rf_mkString(what)) : R_NilValue,
+                       arg ? PROTECT(Rf_mkString(arg)) : R_NilValue);
+
+  PROTECT(call);
+
+  SEXP node = CDR(CDR(CDR(CDR(call))));
+  SET_TAG(node, Rf_install("what"));
+
+  node = CDR(node);
+  SET_TAG(node, Rf_install("arg"));
+
+  Rf_eval(call, R_BaseEnv);
+  Rf_error("Internal error: `stop_bad_vector()` should have thrown earlier");
+}
+
+void stop_bad_element_vector(SEXP x,
+                             R_xlen_t index,
+                             SEXP expected_ptype,
+                             R_xlen_t expected_length,
+                             const char* what,
+                             const char* arg,
+                             bool recycle) {
+  SEXP fn = Rf_lang3(Rf_install(":::"),
+                     Rf_install("purrr"),
+                     Rf_install("stop_bad_element_vector"));
+
+  SEXP call = lang8(PROTECT(fn),
+                    x,
+                    PROTECT(Rf_ScalarReal(index)),
+                    expected_ptype,
+                    PROTECT(Rf_ScalarReal(expected_length)),
+                    what ? PROTECT(Rf_mkString(what)) : R_NilValue,
+                    arg ? PROTECT(Rf_mkString(arg)) : R_NilValue,
+                    PROTECT(Rf_ScalarLogical(recycle)));
+
+  PROTECT(call);
+
+  SEXP node = CDR(CDR(CDR(CDR(CDR(call)))));
+  SET_TAG(node, Rf_install("what"));
+
+  node = CDR(node);
+  SET_TAG(node, Rf_install("arg"));
+
+  node = CDR(node);
+  SET_TAG(node, Rf_install(".recycle"));
+
+  Rf_eval(call, R_BaseEnv);
+  Rf_error("Internal error: `stop_bad_element_length()` should have thrown earlier");
+}

--- a/src/conditions.c
+++ b/src/conditions.c
@@ -25,19 +25,25 @@ void stop_bad_type(SEXP x, const char* expected, const char* what, const char* a
   Rf_error("Internal error: `stop_bad_type()` should have thrown earlier");
 }
 
-void stop_bad_element_type(SEXP x, int index, const char* expected, const char* arg) {
+void stop_bad_element_type(SEXP x, int index, const char* expected, const char* what, const char* arg) {
   SEXP fn = Rf_lang3(Rf_install(":::"),
                      Rf_install("purrr"),
                      Rf_install("stop_bad_element_type"));
 
-  SEXP call = Rf_lang5(PROTECT(fn),
+  SEXP call = Rf_lang6(PROTECT(fn),
                        PROTECT(sym_protect(x)),
                        PROTECT(Rf_ScalarInteger(index)),
                        PROTECT(Rf_mkString(expected)),
+                       what ? PROTECT(Rf_mkString(what)) : R_NilValue,
                        arg ? PROTECT(Rf_mkString(arg)) : R_NilValue);
 
   PROTECT(call);
-  SET_TAG(CDR(CDR(CDR(CDR(call)))), Rf_install("arg"));
+
+  SEXP node = CDR(CDR(CDR(CDR(call))));
+  SET_TAG(node, Rf_install("what"));
+
+  node = CDR(node);
+  SET_TAG(node, Rf_install("arg"));
 
   Rf_eval(call, R_BaseEnv);
   Rf_error("Internal error: `stop_bad_element_type()` should have thrown earlier");

--- a/src/conditions.c
+++ b/src/conditions.c
@@ -25,14 +25,14 @@ void stop_bad_type(SEXP x, const char* expected, const char* what, const char* a
   Rf_error("Internal error: `stop_bad_type()` should have thrown earlier");
 }
 
-void stop_bad_element_type(SEXP x, int index, const char* expected, const char* what, const char* arg) {
+void stop_bad_element_type(SEXP x, R_xlen_t index, const char* expected, const char* what, const char* arg) {
   SEXP fn = Rf_lang3(Rf_install(":::"),
                      Rf_install("purrr"),
                      Rf_install("stop_bad_element_type"));
 
   SEXP call = Rf_lang6(PROTECT(fn),
                        PROTECT(sym_protect(x)),
-                       PROTECT(Rf_ScalarInteger(index)),
+                       PROTECT(Rf_ScalarReal(index)),
                        PROTECT(Rf_mkString(expected)),
                        what ? PROTECT(Rf_mkString(what)) : R_NilValue,
                        arg ? PROTECT(Rf_mkString(arg)) : R_NilValue);

--- a/src/conditions.c
+++ b/src/conditions.c
@@ -50,7 +50,7 @@ void stop_bad_element_type(SEXP x, R_xlen_t index, const char* expected, const c
 }
 
 void stop_bad_length(SEXP x,
-                     R_xlen_t expected,
+                     R_xlen_t expected_length,
                      const char* what,
                      const char* arg,
                      bool recycle) {
@@ -60,7 +60,7 @@ void stop_bad_length(SEXP x,
 
   SEXP call = Rf_lang5(PROTECT(fn),
                        PROTECT(sym_protect(x)),
-                       PROTECT(Rf_ScalarReal(expected)),
+                       PROTECT(Rf_ScalarReal(expected_length)),
                        what ? PROTECT(Rf_mkString(what)) : R_NilValue,
                        arg ? PROTECT(Rf_mkString(arg)) : R_NilValue);
 
@@ -78,7 +78,7 @@ void stop_bad_length(SEXP x,
 
 void stop_bad_element_length(SEXP x,
                              R_xlen_t index,
-                             R_xlen_t expected,
+                             R_xlen_t expected_length,
                              const char* what,
                              const char* arg,
                              bool recycle) {
@@ -89,7 +89,7 @@ void stop_bad_element_length(SEXP x,
   SEXP call = lang7(PROTECT(fn),
                     PROTECT(sym_protect(x)),
                     PROTECT(Rf_ScalarReal(index)),
-                    PROTECT(Rf_ScalarReal(expected)),
+                    PROTECT(Rf_ScalarReal(expected_length)),
                     what ? PROTECT(Rf_mkString(what)) : R_NilValue,
                     arg ? PROTECT(Rf_mkString(arg)) : R_NilValue,
                     PROTECT(Rf_ScalarLogical(recycle)));

--- a/src/conditions.h
+++ b/src/conditions.h
@@ -6,8 +6,12 @@
 
 void stop_bad_type(SEXP x, const char* expected, const char* what, const char* arg) __attribute__((noreturn));
 void stop_bad_element_type(SEXP x, R_xlen_t index, const char* expected, const char* what, const char* arg) __attribute__((noreturn));
+
 void stop_bad_length(SEXP x, R_xlen_t expected_length, const char* what, const char* arg, bool recycle) __attribute__((noreturn));
 void stop_bad_element_length(SEXP x, R_xlen_t index, R_xlen_t expected_length, const char* what, const char* arg, bool recycle) __attribute__((noreturn));
+
+void stop_bad_vector(SEXP x, SEXP expect_ptype, R_xlen_t expected_length, const char* what, const char* arg, bool recycle) __attribute__((noreturn));
+void stop_bad_element_vector(SEXP x, R_xlen_t index, SEXP expect_ptype, R_xlen_t expected_length, const char* what, const char* arg, bool recycle) __attribute__((noreturn));
 
 
 #endif

--- a/src/conditions.h
+++ b/src/conditions.h
@@ -3,7 +3,7 @@
 
 
 void stop_bad_type(SEXP x, const char* expected, const char* what, const char* arg);
-void stop_bad_element_type(SEXP x, int index, const char* expected, const char* what, const char* arg);
+void stop_bad_element_type(SEXP x, R_xlen_t index, const char* expected, const char* what, const char* arg);
 
 
 #endif

--- a/src/conditions.h
+++ b/src/conditions.h
@@ -1,9 +1,13 @@
 #ifndef CONDITIONS_H
 #define CONDITIONS_H
 
+#include <stdbool.h>
 
 
 void stop_bad_type(SEXP x, const char* expected, const char* what, const char* arg) __attribute__((noreturn));
 void stop_bad_element_type(SEXP x, R_xlen_t index, const char* expected, const char* what, const char* arg) __attribute__((noreturn));
+void stop_bad_length(SEXP x, R_xlen_t expected, const char* what, const char* arg, bool recycle) __attribute__((noreturn));
+void stop_bad_element_length(SEXP x, R_xlen_t index, R_xlen_t expected, const char* what, const char* arg, bool recycle) __attribute__((noreturn));
+
 
 #endif

--- a/src/conditions.h
+++ b/src/conditions.h
@@ -1,0 +1,9 @@
+#ifndef CONDITIONS_H
+#define CONDITIONS_H
+
+
+void stop_bad_type(SEXP x, const char* expected, const char* what, const char* arg);
+void stop_bad_element_type(SEXP x, int index, const char* expected, const char* arg);
+
+
+#endif

--- a/src/conditions.h
+++ b/src/conditions.h
@@ -2,8 +2,8 @@
 #define CONDITIONS_H
 
 
-void stop_bad_type(SEXP x, const char* expected, const char* what, const char* arg);
-void stop_bad_element_type(SEXP x, R_xlen_t index, const char* expected, const char* what, const char* arg);
 
+void stop_bad_type(SEXP x, const char* expected, const char* what, const char* arg) __attribute__((noreturn));
+void stop_bad_element_type(SEXP x, R_xlen_t index, const char* expected, const char* what, const char* arg) __attribute__((noreturn));
 
 #endif

--- a/src/conditions.h
+++ b/src/conditions.h
@@ -6,8 +6,8 @@
 
 void stop_bad_type(SEXP x, const char* expected, const char* what, const char* arg) __attribute__((noreturn));
 void stop_bad_element_type(SEXP x, R_xlen_t index, const char* expected, const char* what, const char* arg) __attribute__((noreturn));
-void stop_bad_length(SEXP x, R_xlen_t expected, const char* what, const char* arg, bool recycle) __attribute__((noreturn));
-void stop_bad_element_length(SEXP x, R_xlen_t index, R_xlen_t expected, const char* what, const char* arg, bool recycle) __attribute__((noreturn));
+void stop_bad_length(SEXP x, R_xlen_t expected_length, const char* what, const char* arg, bool recycle) __attribute__((noreturn));
+void stop_bad_element_length(SEXP x, R_xlen_t index, R_xlen_t expected_length, const char* what, const char* arg, bool recycle) __attribute__((noreturn));
 
 
 #endif

--- a/src/conditions.h
+++ b/src/conditions.h
@@ -3,7 +3,7 @@
 
 
 void stop_bad_type(SEXP x, const char* expected, const char* what, const char* arg);
-void stop_bad_element_type(SEXP x, int index, const char* expected, const char* arg);
+void stop_bad_element_type(SEXP x, int index, const char* expected, const char* what, const char* arg);
 
 
 #endif

--- a/src/flatten.c
+++ b/src/flatten.c
@@ -2,6 +2,7 @@
 #include <R.h>
 #include <Rinternals.h>
 #include "coerce.h"
+#include "conditions.h"
 #include "utils.h"
 
 const char* objtype(SEXP x) {
@@ -10,7 +11,7 @@ const char* objtype(SEXP x) {
 
 SEXP flatten_impl(SEXP x) {
   if (TYPEOF(x) != VECSXP) {
-    Rf_errorcall(R_NilValue, "`.x` must be a list, not %s", friendly_typeof(x));
+    stop_bad_type(x, "a list", NULL, ".x");
   }
   int m = Rf_length(x);
 
@@ -21,11 +22,9 @@ SEXP flatten_impl(SEXP x) {
 
   for (int j = 0; j < m; ++j) {
     SEXP x_j = VECTOR_ELT(x, j);
-    if (!Rf_isVector(x_j) && !Rf_isNull(x_j))
-      Rf_errorcall(R_NilValue,
-                   "Element %d of `.x` must be a vector, not %s",
-                   j + 1,
-                   friendly_typeof(x_j));
+    if (!Rf_isVector(x_j) && !Rf_isNull(x_j)) {
+      stop_bad_element_type(x_j, j + 1, "a vector", ".x");
+    }
 
     n += Rf_length(x_j);
     if (!has_names) {
@@ -62,7 +61,7 @@ SEXP flatten_impl(SEXP x) {
       case STRSXP:   SET_VECTOR_ELT(out, i, Rf_ScalarString(STRING_ELT(x_j, k))); break;
       case VECSXP:   SET_VECTOR_ELT(out, i, VECTOR_ELT(x_j, k)); break;
       default:
-        Rf_errorcall(R_NilValue, "Element %d must be a vector, not %s", j + 1, friendly_typeof(x_j));
+        Rf_error("Internal error: `flatten_impl()` should have failed earlier");
       }
       if (has_names) {
         if (has_names_j) {
@@ -86,7 +85,7 @@ SEXP flatten_impl(SEXP x) {
 
 SEXP vflatten_impl(SEXP x, SEXP type_) {
   if (TYPEOF(x) != VECSXP) {
-    Rf_errorcall(R_NilValue, "`.x` must be a list, not %s", friendly_typeof(x));
+    stop_bad_type(x, "a list", NULL, ".x");
   }
   int m = Rf_length(x);
 

--- a/src/flatten.c
+++ b/src/flatten.c
@@ -22,7 +22,7 @@ SEXP flatten_impl(SEXP x) {
 
   for (int j = 0; j < m; ++j) {
     SEXP x_j = VECTOR_ELT(x, j);
-    if (!Rf_isVector(x_j) && !Rf_isNull(x_j)) {
+    if (!is_vector(x_j) && x_j != R_NilValue) {
       stop_bad_element_type(x_j, j + 1, "a vector", ".x");
     }
 
@@ -58,7 +58,9 @@ SEXP flatten_impl(SEXP x) {
       case LGLSXP:   SET_VECTOR_ELT(out, i, Rf_ScalarLogical(LOGICAL(x_j)[k])); break;
       case INTSXP:   SET_VECTOR_ELT(out, i, Rf_ScalarInteger(INTEGER(x_j)[k])); break;
       case REALSXP:  SET_VECTOR_ELT(out, i, Rf_ScalarReal(REAL(x_j)[k])); break;
+      case CPLXSXP:  SET_VECTOR_ELT(out, i, Rf_ScalarComplex(COMPLEX(x_j)[k])); break;
       case STRSXP:   SET_VECTOR_ELT(out, i, Rf_ScalarString(STRING_ELT(x_j, k))); break;
+      case RAWSXP:   SET_VECTOR_ELT(out, i, Rf_ScalarRaw(RAW(x_j)[k])); break;
       case VECSXP:   SET_VECTOR_ELT(out, i, VECTOR_ELT(x_j, k)); break;
       default:
         Rf_error("Internal error: `flatten_impl()` should have failed earlier");

--- a/src/flatten.c
+++ b/src/flatten.c
@@ -23,7 +23,7 @@ SEXP flatten_impl(SEXP x) {
   for (int j = 0; j < m; ++j) {
     SEXP x_j = VECTOR_ELT(x, j);
     if (!is_vector(x_j) && x_j != R_NilValue) {
-      stop_bad_element_type(x_j, j + 1, "a vector", ".x");
+      stop_bad_element_type(x_j, j + 1, "a vector", NULL, ".x");
     }
 
     n += Rf_length(x_j);

--- a/src/map.c
+++ b/src/map.c
@@ -152,7 +152,7 @@ SEXP pmap_impl(SEXP env, SEXP l_name_, SEXP f_name_, SEXP type_) {
     SEXP j_val = VECTOR_ELT(l_val, j);
 
     if (!Rf_isVector(j_val) && !Rf_isNull(j_val)) {
-      stop_bad_element_type(j_val, j + 1, "a vector", l_name);
+      stop_bad_element_type(j_val, j + 1, "a vector", NULL, l_name);
     }
 
     int nj = Rf_length(j_val);

--- a/src/map.c
+++ b/src/map.c
@@ -3,6 +3,7 @@
 #include <Rversion.h>
 #include <Rinternals.h>
 #include "coerce.h"
+#include "conditions.h"
 #include "utils.h"
 
 void copy_names(SEXP from, SEXP to) {
@@ -17,15 +18,11 @@ void copy_names(SEXP from, SEXP to) {
 }
 
 void check_vector(SEXP x, const char *name) {
-  if (Rf_isNull(x) || Rf_isVector(x) || Rf_isPairList(x))
+  if (Rf_isNull(x) || Rf_isVector(x) || Rf_isPairList(x)) {
     return;
+  }
 
-  Rf_errorcall(
-    R_NilValue,
-    "`%s` must be a vector, not %s",
-    name,
-    friendly_typeof(x)
-  );
+  stop_bad_type(x, "a vector", NULL, name);
 }
 
 // call must involve i
@@ -145,9 +142,7 @@ SEXP pmap_impl(SEXP env, SEXP l_name_, SEXP f_name_, SEXP type_) {
   SEXPTYPE type = Rf_str2type(CHAR(Rf_asChar(type_)));
 
   if (!Rf_isVectorList(l_val)) {
-    Rf_errorcall(R_NilValue,
-                 "`.x` must be a list, not %s",
-                 friendly_typeof(l_val));
+    stop_bad_type(l_val, "a list", NULL, l_name);
   }
 
   // Check all elements are lists and find maximum length
@@ -157,10 +152,7 @@ SEXP pmap_impl(SEXP env, SEXP l_name_, SEXP f_name_, SEXP type_) {
     SEXP j_val = VECTOR_ELT(l_val, j);
 
     if (!Rf_isVector(j_val) && !Rf_isNull(j_val)) {
-      Rf_errorcall(R_NilValue,
-                   "Element %d of `.l` must be a vector, not %s",
-                   j + 1,
-                   friendly_typeof(j_val));
+      stop_bad_element_type(j_val, j + 1, "a vector", l_name);
     }
 
     int nj = Rf_length(j_val);

--- a/src/map.c
+++ b/src/map.c
@@ -44,13 +44,10 @@ SEXP call_loop(SEXP env, SEXP call, int n, SEXPTYPE type, int force_args) {
 #else
     SEXP res = PROTECT(Rf_eval(call, env));
 #endif
-    if (type != VECSXP && Rf_length(res) != 1)
-      Rf_errorcall(R_NilValue,
-                   "Result %i must be a single %s, not %s of length %d",
-                   i + 1,
-                   Rf_type2char(type),
-                   friendly_typeof(res),
-                   Rf_length(res));
+    if (type != VECSXP && Rf_length(res) != 1) {
+      SEXP ptype = PROTECT(Rf_allocVector(type, 0));
+      stop_bad_element_vector(res, i + 1, ptype, 1, "Result", NULL, false);
+    }
 
     set_vector_value(out, i, res, 0);
     UNPROTECT(1);

--- a/src/map.c
+++ b/src/map.c
@@ -172,11 +172,7 @@ SEXP pmap_impl(SEXP env, SEXP l_name_, SEXP f_name_, SEXP type_) {
     int nj = Rf_length(j_val);
 
     if (nj != 1 && nj != n) {
-      Rf_errorcall(R_NilValue,
-                   "Element %d of `.l` must have length 1 or %d, not %d",
-                   j + 1,
-                   nj,
-                   n);
+      stop_bad_element_length(j_val, j + 1, n, NULL, ".l", true);
     }
   }
 

--- a/src/pluck.c
+++ b/src/pluck.c
@@ -140,7 +140,8 @@ SEXP extract_vector(SEXP x, SEXP index_i, int i, bool strict) {
 
 SEXP extract_env(SEXP x, SEXP index_i, int i, bool strict) {
   if (TYPEOF(index_i) != STRSXP || Rf_length(index_i) != 1) {
-    Rf_errorcall(R_NilValue, "Index %d must be a string.", i + 1);
+    SEXP ptype = PROTECT(Rf_allocVector(STRSXP, 0));
+    stop_bad_element_vector(index_i, i + 1, ptype, 1, "Index", NULL, false);
   }
 
   SEXP index = STRING_ELT(index_i, 0);
@@ -160,7 +161,8 @@ SEXP extract_env(SEXP x, SEXP index_i, int i, bool strict) {
 
 SEXP extract_s4(SEXP x, SEXP index_i, int i, bool strict) {
   if (TYPEOF(index_i) != STRSXP || Rf_length(index_i) != 1) {
-    Rf_errorcall(R_NilValue, "Index %d must be a string.", i + 1);
+    SEXP ptype = PROTECT(Rf_allocVector(STRSXP, 0));
+    stop_bad_element_vector(index_i, i + 1, ptype, 1, "Index", NULL, false);
   }
 
   SEXP index = STRING_ELT(index_i, 0);

--- a/src/pluck.c
+++ b/src/pluck.c
@@ -195,7 +195,7 @@ static bool is_function(SEXP x) {
 
 SEXP pluck_impl(SEXP x, SEXP index, SEXP missing, SEXP strict_arg) {
   if (TYPEOF(index) != VECSXP) {
-    Rf_errorcall(R_NilValue, "`index` must be a list, not a %s", Rf_type2char(TYPEOF(index)));
+    stop_bad_type(index, "a list", NULL, "where");
   }
 
   int n = Rf_length(index);

--- a/src/pluck.c
+++ b/src/pluck.c
@@ -2,9 +2,10 @@
 #include <R.h>
 #include <Rinternals.h>
 #include <stdbool.h>
-#include "coerce.h"
-#include "backports.h"
 #include <string.h>
+#include "backports.h"
+#include "coerce.h"
+#include "conditions.h"
 
 static int check_input_lengths(int n, int index_n, int i, bool strict);
 static int check_double_index_finiteness(double val, SEXP index, int i, bool strict);
@@ -100,7 +101,7 @@ int find_offset(SEXP x, SEXP index, int i, bool strict) {
   }
 
   default:
-    Rf_errorcall(R_NilValue, "Index %d must be a character or numeric vector.", i + 1);
+    stop_bad_element_type(x, i + 1, "a character or numeric vector", "Index", NULL);
   }
 }
 

--- a/src/pluck.c
+++ b/src/pluck.c
@@ -7,7 +7,7 @@
 #include "coerce.h"
 #include "conditions.h"
 
-static int check_input_lengths(int n, int index_n, int i, bool strict);
+static int check_input_lengths(int n, SEXP index, int i, bool strict);
 static int check_double_index_finiteness(double val, SEXP index, int i, bool strict);
 static int check_double_index_length(double val, int n, int i, bool strict);
 static int check_character_index(SEXP string, int i, bool strict);
@@ -29,7 +29,7 @@ int find_offset(SEXP x, SEXP index, int i, bool strict) {
     return -1;
   }
 
-  if (check_input_lengths(n, Rf_length(index), i, strict)) {
+  if (check_input_lengths(n, index, i, strict)) {
     return -1;
   }
 
@@ -253,7 +253,9 @@ SEXP pluck_impl(SEXP x, SEXP index, SEXP missing, SEXP strict_arg) {
 
 /* Type checking */
 
-static int check_input_lengths(int n, int index_n, int i, bool strict) {
+static int check_input_lengths(int n, SEXP index, int i, bool strict) {
+  int index_n = Rf_length(index);
+
   if (n == 0) {
     if (strict) {
       Rf_errorcall(R_NilValue, "Plucked object must have at least one element.");
@@ -262,10 +264,8 @@ static int check_input_lengths(int n, int index_n, int i, bool strict) {
     }
   }
 
-  if (index_n > 1) {
-    Rf_errorcall(R_NilValue, "Index %d must have length 1, not %d.", i + 1, n);
-  } else if (strict && index_n == 0) {
-    Rf_errorcall(R_NilValue, "Index %d must have length 1, not 0.", i + 1);
+  if (index_n > 1 || (strict && index_n == 0)) {
+    stop_bad_element_length(index, i + 1, 1, "Index", NULL, false);
   }
 
   return 0;

--- a/src/transpose.c
+++ b/src/transpose.c
@@ -1,11 +1,12 @@
 #define R_NO_REMAP
 #include <R.h>
 #include <Rinternals.h>
+#include "conditions.h"
 #include "utils.h"
 
 SEXP transpose_impl(SEXP x, SEXP names_template) {
   if (TYPEOF(x) != VECSXP) {
-    Rf_errorcall(R_NilValue, "`.l` must be a list, not %s", friendly_typeof(x));
+    stop_bad_type(x, "a list", NULL, ".l");
   }
 
   int n = Rf_length(x);
@@ -17,7 +18,7 @@ SEXP transpose_impl(SEXP x, SEXP names_template) {
 
   SEXP x1 = VECTOR_ELT(x, 0);
   if (!Rf_isVector(x1)) {
-    Rf_errorcall(R_NilValue, "Element 1 must be a vector, not %s", friendly_typeof(x1));
+    stop_bad_element_type(x1, 1, "a vector", NULL);
   }
   int m = has_template ? Rf_length(names_template) : Rf_length(x1);
 
@@ -43,7 +44,7 @@ SEXP transpose_impl(SEXP x, SEXP names_template) {
   for (int i = 0; i < n; ++i) {
     SEXP xi = VECTOR_ELT(x, i);
     if (!Rf_isVector(xi)) {
-      Rf_errorcall(R_NilValue, "Element %d must be a vector, not %s", i + 1, friendly_typeof(xi));
+      stop_bad_element_type(xi, i + 1, "a vector", NULL);
     }
 
 
@@ -92,9 +93,7 @@ SEXP transpose_impl(SEXP x, SEXP names_template) {
         SET_VECTOR_ELT(VECTOR_ELT(out, j), i, VECTOR_ELT(xi, pos));
         break;
       default:
-        Rf_errorcall(R_NilValue,
-                     "Transposed element must be a vector, not %s",
-                     friendly_typeof(xi));
+        stop_bad_type(xi, "a vector", "Transposed element", NULL);
       }
     }
 

--- a/src/transpose.c
+++ b/src/transpose.c
@@ -18,7 +18,7 @@ SEXP transpose_impl(SEXP x, SEXP names_template) {
 
   SEXP x1 = VECTOR_ELT(x, 0);
   if (!Rf_isVector(x1)) {
-    stop_bad_element_type(x1, 1, "a vector", NULL);
+    stop_bad_element_type(x1, 1, "a vector", NULL, NULL);
   }
   int m = has_template ? Rf_length(names_template) : Rf_length(x1);
 
@@ -44,7 +44,7 @@ SEXP transpose_impl(SEXP x, SEXP names_template) {
   for (int i = 0; i < n; ++i) {
     SEXP xi = VECTOR_ELT(x, i);
     if (!Rf_isVector(xi)) {
-      stop_bad_element_type(xi, i + 1, "a vector", NULL);
+      stop_bad_element_type(xi, i + 1, "a vector", NULL, NULL);
     }
 
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,5 +1,6 @@
 #define R_NO_REMAP
 #include <Rinternals.h>
+#include <stdbool.h>
 
 SEXP sym_protect(SEXP x) {
   if (TYPEOF(x) == LANGSXP || TYPEOF(x) == SYMSXP) {
@@ -21,4 +22,19 @@ const char* friendly_typeof(SEXP x) {
   UNPROTECT(2);
 
   return CHAR(STRING_ELT(type, 0));
+}
+
+bool is_vector(SEXP x) {
+  switch (TYPEOF(x)) {
+  case LGLSXP:
+  case INTSXP:
+  case REALSXP:
+  case CPLXSXP:
+  case STRSXP:
+  case RAWSXP:
+  case VECSXP:
+    return true;
+  default:
+    return false;
+  }
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -45,3 +45,15 @@ SEXP lang7(SEXP s, SEXP t, SEXP u, SEXP v, SEXP w, SEXP x, SEXP y) {
   UNPROTECT(1);
   return s;
 }
+SEXP list7(SEXP s, SEXP t, SEXP u, SEXP v, SEXP w, SEXP x, SEXP y) {
+  PROTECT(s);
+  s = Rf_cons(s, Rf_list6(t, u, v, w, x, y));
+  UNPROTECT(1);
+  return s;
+}
+SEXP lang8(SEXP s, SEXP t, SEXP u, SEXP v, SEXP w, SEXP x, SEXP y, SEXP z) {
+  PROTECT(s);
+  s = Rf_lcons(s, list7(t, u, v, w, x, y, z));
+  UNPROTECT(1);
+  return s;
+}

--- a/src/utils.c
+++ b/src/utils.c
@@ -38,3 +38,10 @@ bool is_vector(SEXP x) {
     return false;
   }
 }
+
+SEXP lang7(SEXP s, SEXP t, SEXP u, SEXP v, SEXP w, SEXP x, SEXP y) {
+  PROTECT(s);
+  s = Rf_lcons(s, Rf_list6(t, u, v, w, x, y));
+  UNPROTECT(1);
+  return s;
+}

--- a/src/utils.c
+++ b/src/utils.c
@@ -39,15 +39,22 @@ bool is_vector(SEXP x) {
   }
 }
 
+SEXP list6(SEXP s, SEXP t, SEXP u, SEXP v, SEXP w, SEXP x) {
+  PROTECT(s);
+  s = Rf_cons(s, Rf_list5(t, u, v, w, x));
+  UNPROTECT(1);
+  return s;
+}
+
 SEXP lang7(SEXP s, SEXP t, SEXP u, SEXP v, SEXP w, SEXP x, SEXP y) {
   PROTECT(s);
-  s = Rf_lcons(s, Rf_list6(t, u, v, w, x, y));
+  s = Rf_lcons(s, list6(t, u, v, w, x, y));
   UNPROTECT(1);
   return s;
 }
 SEXP list7(SEXP s, SEXP t, SEXP u, SEXP v, SEXP w, SEXP x, SEXP y) {
   PROTECT(s);
-  s = Rf_cons(s, Rf_list6(t, u, v, w, x, y));
+  s = Rf_cons(s, list6(t, u, v, w, x, y));
   UNPROTECT(1);
   return s;
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,12 +1,16 @@
 #ifndef UTILS_H
 #define UTILS_H
 
+#include <stdbool.h>
+
 
 SEXP sym_protect(SEXP x);
 
 // The return value might be garbage-collected so should be used in
 // non-jumpy context
 const char* friendly_typeof(SEXP x);
+
+bool is_vector(SEXP x);
 
 
 #endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -2,6 +2,8 @@
 #define UTILS_H
 
 
+SEXP sym_protect(SEXP x);
+
 // The return value might be garbage-collected so should be used in
 // non-jumpy context
 const char* friendly_typeof(SEXP x);

--- a/src/utils.h
+++ b/src/utils.h
@@ -13,6 +13,7 @@ const char* friendly_typeof(SEXP x);
 bool is_vector(SEXP x);
 
 SEXP lang7(SEXP s, SEXP t, SEXP u, SEXP v, SEXP w, SEXP x, SEXP y);
+SEXP lang8(SEXP s, SEXP t, SEXP u, SEXP v, SEXP w, SEXP x, SEXP y, SEXP z);
 
 
 #endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -12,5 +12,7 @@ const char* friendly_typeof(SEXP x);
 
 bool is_vector(SEXP x);
 
+SEXP lang7(SEXP s, SEXP t, SEXP u, SEXP v, SEXP w, SEXP x, SEXP y);
+
 
 #endif

--- a/tests/testthat/helper-conditions.R
+++ b/tests/testthat/helper-conditions.R
@@ -1,0 +1,6 @@
+
+expect_error_cnd <- function(expr, regexp, class, ...) {
+  err <- catch_cnd(expr)
+  expect_true(inherits_all(err, c(class, "error", "condition")))
+  expect_match(conditionMessage(err), regexp, ...)
+}

--- a/tests/testthat/test-conditions.R
+++ b/tests/testthat/test-conditions.R
@@ -1,0 +1,21 @@
+context("conditions")
+
+test_that("stop_bad_element_type() constructs type errors", {
+  expect_error(
+    stop_bad_element_type(1:3, 3, "a foobaz"),
+    "Element 3 must be a foobaz, not an integer vector",
+    "purrr_error_bad_element_type"
+  )
+
+  expect_error(
+    stop_bad_element_type(1:3, 3, "a foobaz", actual = "a quux"),
+    "Element 3 must be a foobaz, not a quux",
+    "purrr_error_bad_element_type"
+  )
+
+  expect_error(
+    stop_bad_element_type(1:3, 3, "a foobaz", arg = "..arg"),
+    "Element 3 of `..arg` must be a foobaz, not an integer vector",
+    "purrr_error_bad_element_type"
+  )
+})

--- a/tests/testthat/test-conditions.R
+++ b/tests/testthat/test-conditions.R
@@ -74,3 +74,17 @@ test_that("stop_bad_element_length() constructs error message", {
   expect_error(stop_bad_element_length(1:3, 8, 10, arg = ".foo"), "Element 8 of `.foo` must have length 10, not 3")
   expect_error(stop_bad_element_length(1:3, 8, 10, arg = ".foo", what = "Result"), "Result 8 of `.foo` must have length 10, not 3")
 })
+
+test_that("stop_bad_vector() constructs error message", {
+  expect_error(stop_bad_vector(1:3, character(), 1), "Vector must be a single string, not an integer vector of length 3")
+  expect_error(stop_bad_vector(factor(c("a", "b")), character(), 10), "Vector must be a character vector of length 10, not a vector of class `factor` and of length 2")
+  expect_error(stop_bad_vector(1:3, character(), 10, .recycle = TRUE), "Vector must be a character vector of length 1 or 10, not an integer vector of length 3")
+  expect_error(stop_bad_vector(1:3, 1:2, 10, what = "This foobaz vector", .recycle = TRUE), "This foobaz vector must be an integer vector of length 1 or 10, not an integer vector of length 3")
+  expect_error(stop_bad_vector(list(1, 2), logical(), 10, arg = ".quux", .recycle = TRUE), "`.quux` must be a logical vector of length 1 or 10, not a list of length 2")
+})
+
+test_that("stop_bad_element_vector() constructs error message", {
+  expect_error(stop_bad_element_vector(1:3, 3, character(), 1), "Element 3 must be a single string, not an integer vector of length 3")
+  expect_error(stop_bad_element_vector(1:3, 20, 1:2, 10, what = "Result", .recycle = TRUE), "Result 20 must be an integer vector of length 1 or 10, not an integer vector of length 3")
+  expect_error(stop_bad_element_vector(list(1, 2), 1, logical(), 10, arg = ".quux", .recycle = TRUE), "Element 1 of `.quux` must be a logical vector of length 1 or 10, not a list of length 2")
+})

--- a/tests/testthat/test-conditions.R
+++ b/tests/testthat/test-conditions.R
@@ -1,5 +1,32 @@
 context("conditions")
 
+test_that("stop_bad_type() stores fields", {
+  err <- catch_cnd(stop_bad_type(NA, "`NULL`", actual = "a foobaz", arg = ".foo"))
+  expect_is(err, "purrr_error_bad_type")
+  expect_identical(err$x, NA)
+  expect_identical(err$expected, "`NULL`")
+  expect_identical(err$actual, "a foobaz")
+  expect_identical(err$arg, ".foo")
+})
+
+test_that("stop_bad_type() constructs default `what`", {
+  expect_error(
+    stop_bad_type(NA, "`NULL`"),
+    "Object must be `NULL`",
+    "purrr_error_bad_type"
+  )
+  expect_error(
+    stop_bad_type(NA, "`NULL`", arg = ".foo"),
+    "`.foo` must be `NULL`",
+    "purrr_error_bad_type"
+  )
+  expect_error(
+    stop_bad_type(NA, "`NULL`", arg = quote(.foo)),
+    "`arg` must be `NULL` or a string, not a symbol",
+    "purrr_error_bad_type"
+  )
+})
+
 test_that("stop_bad_element_type() constructs type errors", {
   expect_error(
     stop_bad_element_type(1:3, 3, "a foobaz"),

--- a/tests/testthat/test-conditions.R
+++ b/tests/testthat/test-conditions.R
@@ -67,24 +67,26 @@ test_that("stop_bad_length() constructs error message", {
   expect_error_cnd(stop_bad_length(1:3, 10), "Vector must have length 10, not 3", "purrr_error_bad_length")
   expect_error_cnd(stop_bad_length(1:3, 10, arg = ".foo"), "`.foo` must have length 10, not 3", "purrr_error_bad_length")
   expect_error_cnd(stop_bad_length(1:3, 10, arg = ".foo", what = "This thing"), "This thing must have length 10, not 3", "purrr_error_bad_length")
+  expect_error_cnd(stop_bad_length(1:3, 10, arg = ".foo", what = "This thing", recycle = TRUE), "This thing must have length 1 or 10, not 3", "purrr_error_bad_length")
 })
 
 test_that("stop_bad_element_length() constructs error message", {
   expect_error_cnd(stop_bad_element_length(1:3, 8, 10), "Element 8 must have length 10, not 3", "purrr_error_bad_element_length")
   expect_error_cnd(stop_bad_element_length(1:3, 8, 10, arg = ".foo"), "Element 8 of `.foo` must have length 10, not 3", "purrr_error_bad_element_length")
   expect_error_cnd(stop_bad_element_length(1:3, 8, 10, arg = ".foo", what = "Result"), "Result 8 of `.foo` must have length 10, not 3", "purrr_error_bad_element_length")
+  expect_error_cnd(stop_bad_element_length(1:3, 8, 10, arg = ".foo", what = "Result", recycle = TRUE), "Result 8 of `.foo` must have length 1 or 10, not 3", "purrr_error_bad_element_length")
 })
 
 test_that("stop_bad_vector() constructs error message", {
   expect_error_cnd(stop_bad_vector(1:3, character(), 1), "Vector must be a single string, not an integer vector of length 3", "purrr_error_bad_vector")
   expect_error_cnd(stop_bad_vector(factor(c("a", "b")), character(), 10), "Vector must be a character vector of length 10, not a vector of class `factor` and of length 2", "purrr_error_bad_vector")
-  expect_error_cnd(stop_bad_vector(1:3, character(), 10, .recycle = TRUE), "Vector must be a character vector of length 1 or 10, not an integer vector of length 3", "purrr_error_bad_vector")
-  expect_error_cnd(stop_bad_vector(1:3, 1:2, 10, what = "This foobaz vector", .recycle = TRUE), "This foobaz vector must be an integer vector of length 1 or 10, not an integer vector of length 3", "purrr_error_bad_vector")
-  expect_error_cnd(stop_bad_vector(list(1, 2), logical(), 10, arg = ".quux", .recycle = TRUE), "`.quux` must be a logical vector of length 1 or 10, not a list of length 2", "purrr_error_bad_vector")
+  expect_error_cnd(stop_bad_vector(1:3, character(), 10, recycle = TRUE), "Vector must be a character vector of length 1 or 10, not an integer vector of length 3", "purrr_error_bad_vector")
+  expect_error_cnd(stop_bad_vector(1:3, 1:2, 10, what = "This foobaz vector", recycle = TRUE), "This foobaz vector must be an integer vector of length 1 or 10, not an integer vector of length 3", "purrr_error_bad_vector")
+  expect_error_cnd(stop_bad_vector(list(1, 2), logical(), 10, arg = ".quux", recycle = TRUE), "`.quux` must be a logical vector of length 1 or 10, not a list of length 2", "purrr_error_bad_vector")
 })
 
 test_that("stop_bad_element_vector() constructs error message", {
   expect_error_cnd(stop_bad_element_vector(1:3, 3, character(), 1), "Element 3 must be a single string, not an integer vector of length 3", "purrr_error_bad_element_vector")
-  expect_error_cnd(stop_bad_element_vector(1:3, 20, 1:2, 10, what = "Result", .recycle = TRUE), "Result 20 must be an integer vector of length 1 or 10, not an integer vector of length 3", "purrr_error_bad_element_vector")
-  expect_error_cnd(stop_bad_element_vector(list(1, 2), 1, logical(), 10, arg = ".quux", .recycle = TRUE), "Element 1 of `.quux` must be a logical vector of length 1 or 10, not a list of length 2", "purrr_error_bad_element_vector")
+  expect_error_cnd(stop_bad_element_vector(1:3, 20, 1:2, 10, what = "Result", recycle = TRUE), "Result 20 must be an integer vector of length 1 or 10, not an integer vector of length 3", "purrr_error_bad_element_vector")
+  expect_error_cnd(stop_bad_element_vector(list(1, 2), 1, logical(), 10, arg = ".quux", recycle = TRUE), "Element 1 of `.quux` must be a logical vector of length 1 or 10, not a list of length 2", "purrr_error_bad_element_vector")
 })

--- a/tests/testthat/test-conditions.R
+++ b/tests/testthat/test-conditions.R
@@ -10,17 +10,17 @@ test_that("stop_bad_type() stores fields", {
 })
 
 test_that("stop_bad_type() constructs default `what`", {
-  expect_error(
+  expect_error_cnd(
     stop_bad_type(NA, "`NULL`"),
     "Object must be `NULL`",
     "purrr_error_bad_type"
   )
-  expect_error(
+  expect_error_cnd(
     stop_bad_type(NA, "`NULL`", arg = ".foo"),
     "`.foo` must be `NULL`",
     "purrr_error_bad_type"
   )
-  expect_error(
+  expect_error_cnd(
     stop_bad_type(NA, "`NULL`", arg = quote(.foo)),
     "`arg` must be `NULL` or a string, not a symbol",
     "purrr_error_bad_type"
@@ -28,19 +28,19 @@ test_that("stop_bad_type() constructs default `what`", {
 })
 
 test_that("stop_bad_element_type() constructs type errors", {
-  expect_error(
+  expect_error_cnd(
     stop_bad_element_type(1:3, 3, "a foobaz"),
     "Element 3 must be a foobaz, not an integer vector",
     "purrr_error_bad_element_type"
   )
 
-  expect_error(
+  expect_error_cnd(
     stop_bad_element_type(1:3, 3, "a foobaz", actual = "a quux"),
     "Element 3 must be a foobaz, not a quux",
     "purrr_error_bad_element_type"
   )
 
-  expect_error(
+  expect_error_cnd(
     stop_bad_element_type(1:3, 3, "a foobaz", arg = "..arg"),
     "Element 3 of `..arg` must be a foobaz, not an integer vector",
     "purrr_error_bad_element_type"
@@ -48,7 +48,7 @@ test_that("stop_bad_element_type() constructs type errors", {
 })
 
 test_that("stop_bad_element_type() accepts `what`", {
-  expect_error(
+  expect_error_cnd(
     stop_bad_element_type(1:3, 3, "a foobaz", what = "Result"),
     "Result 3 must be a foobaz, not an integer vector",
     "purrr_error_bad_element_type"
@@ -64,27 +64,27 @@ test_that("stop_bad_length() stores fields", {
 })
 
 test_that("stop_bad_length() constructs error message", {
-  expect_error(stop_bad_length(1:3, 10), "Vector must have length 10, not 3")
-  expect_error(stop_bad_length(1:3, 10, arg = ".foo"), "`.foo` must have length 10, not 3")
-  expect_error(stop_bad_length(1:3, 10, arg = ".foo", what = "This thing"), "This thing must have length 10, not 3")
+  expect_error_cnd(stop_bad_length(1:3, 10), "Vector must have length 10, not 3", "purrr_error_bad_length")
+  expect_error_cnd(stop_bad_length(1:3, 10, arg = ".foo"), "`.foo` must have length 10, not 3", "purrr_error_bad_length")
+  expect_error_cnd(stop_bad_length(1:3, 10, arg = ".foo", what = "This thing"), "This thing must have length 10, not 3", "purrr_error_bad_length")
 })
 
 test_that("stop_bad_element_length() constructs error message", {
-  expect_error(stop_bad_element_length(1:3, 8, 10), "Element 8 must have length 10, not 3")
-  expect_error(stop_bad_element_length(1:3, 8, 10, arg = ".foo"), "Element 8 of `.foo` must have length 10, not 3")
-  expect_error(stop_bad_element_length(1:3, 8, 10, arg = ".foo", what = "Result"), "Result 8 of `.foo` must have length 10, not 3")
+  expect_error_cnd(stop_bad_element_length(1:3, 8, 10), "Element 8 must have length 10, not 3", "purrr_error_bad_element_length")
+  expect_error_cnd(stop_bad_element_length(1:3, 8, 10, arg = ".foo"), "Element 8 of `.foo` must have length 10, not 3", "purrr_error_bad_element_length")
+  expect_error_cnd(stop_bad_element_length(1:3, 8, 10, arg = ".foo", what = "Result"), "Result 8 of `.foo` must have length 10, not 3", "purrr_error_bad_element_length")
 })
 
 test_that("stop_bad_vector() constructs error message", {
-  expect_error(stop_bad_vector(1:3, character(), 1), "Vector must be a single string, not an integer vector of length 3")
-  expect_error(stop_bad_vector(factor(c("a", "b")), character(), 10), "Vector must be a character vector of length 10, not a vector of class `factor` and of length 2")
-  expect_error(stop_bad_vector(1:3, character(), 10, .recycle = TRUE), "Vector must be a character vector of length 1 or 10, not an integer vector of length 3")
-  expect_error(stop_bad_vector(1:3, 1:2, 10, what = "This foobaz vector", .recycle = TRUE), "This foobaz vector must be an integer vector of length 1 or 10, not an integer vector of length 3")
-  expect_error(stop_bad_vector(list(1, 2), logical(), 10, arg = ".quux", .recycle = TRUE), "`.quux` must be a logical vector of length 1 or 10, not a list of length 2")
+  expect_error_cnd(stop_bad_vector(1:3, character(), 1), "Vector must be a single string, not an integer vector of length 3", "purrr_error_bad_vector")
+  expect_error_cnd(stop_bad_vector(factor(c("a", "b")), character(), 10), "Vector must be a character vector of length 10, not a vector of class `factor` and of length 2", "purrr_error_bad_vector")
+  expect_error_cnd(stop_bad_vector(1:3, character(), 10, .recycle = TRUE), "Vector must be a character vector of length 1 or 10, not an integer vector of length 3", "purrr_error_bad_vector")
+  expect_error_cnd(stop_bad_vector(1:3, 1:2, 10, what = "This foobaz vector", .recycle = TRUE), "This foobaz vector must be an integer vector of length 1 or 10, not an integer vector of length 3", "purrr_error_bad_vector")
+  expect_error_cnd(stop_bad_vector(list(1, 2), logical(), 10, arg = ".quux", .recycle = TRUE), "`.quux` must be a logical vector of length 1 or 10, not a list of length 2", "purrr_error_bad_vector")
 })
 
 test_that("stop_bad_element_vector() constructs error message", {
-  expect_error(stop_bad_element_vector(1:3, 3, character(), 1), "Element 3 must be a single string, not an integer vector of length 3")
-  expect_error(stop_bad_element_vector(1:3, 20, 1:2, 10, what = "Result", .recycle = TRUE), "Result 20 must be an integer vector of length 1 or 10, not an integer vector of length 3")
-  expect_error(stop_bad_element_vector(list(1, 2), 1, logical(), 10, arg = ".quux", .recycle = TRUE), "Element 1 of `.quux` must be a logical vector of length 1 or 10, not a list of length 2")
+  expect_error_cnd(stop_bad_element_vector(1:3, 3, character(), 1), "Element 3 must be a single string, not an integer vector of length 3", "purrr_error_bad_element_vector")
+  expect_error_cnd(stop_bad_element_vector(1:3, 20, 1:2, 10, what = "Result", .recycle = TRUE), "Result 20 must be an integer vector of length 1 or 10, not an integer vector of length 3", "purrr_error_bad_element_vector")
+  expect_error_cnd(stop_bad_element_vector(list(1, 2), 1, logical(), 10, arg = ".quux", .recycle = TRUE), "Element 1 of `.quux` must be a logical vector of length 1 or 10, not a list of length 2", "purrr_error_bad_element_vector")
 })

--- a/tests/testthat/test-conditions.R
+++ b/tests/testthat/test-conditions.R
@@ -54,3 +54,25 @@ test_that("stop_bad_element_type() accepts `what`", {
     "purrr_error_bad_element_type"
   )
 })
+
+test_that("stop_bad_length() stores fields", {
+  err <- catch_cnd(stop_bad_length(1:3, 10, actual = 100, arg = ".foo"))
+  expect_is(err, "purrr_error_bad_length")
+  expect_identical(err$x, 1:3)
+  expect_identical(err$expected, 10)
+  expect_identical(err$actual, 100)
+  expect_identical(err$arg, ".foo")
+})
+
+test_that("stop_bad_length() constructs error message", {
+  expect_error(stop_bad_length(1:3, 10), "Vector must have length 10, not 3")
+  expect_error(stop_bad_length(1:3, 10, arg = ".foo"), "`.foo` must have length 10, not 3")
+  expect_error(stop_bad_length(1:3, 10, actual = 100, arg = ".foo"), "`.foo` must have length 10, not 100")
+  expect_error(stop_bad_length(1:3, 10, actual = 100, arg = ".foo", what = "This thing"), "This thing must have length 10, not 100")
+})
+
+test_that("stop_bad_element_length() constructs error message", {
+  expect_error(stop_bad_element_length(1:3, 8, 10), "Element 8 must have length 10, not 3")
+  expect_error(stop_bad_element_length(1:3, 8, 10, arg = ".foo"), "Element 8 of `.foo` must have length 10, not 3")
+  expect_error(stop_bad_element_length(1:3, 8, 10, arg = ".foo", what = "Result"), "Result 8 of `.foo` must have length 10, not 3")
+})

--- a/tests/testthat/test-conditions.R
+++ b/tests/testthat/test-conditions.R
@@ -59,16 +59,14 @@ test_that("stop_bad_length() stores fields", {
   err <- catch_cnd(stop_bad_length(1:3, 10, actual = 100, arg = ".foo"))
   expect_is(err, "purrr_error_bad_length")
   expect_identical(err$x, 1:3)
-  expect_identical(err$expected, 10)
-  expect_identical(err$actual, 100)
+  expect_identical(err$expected_length, 10)
   expect_identical(err$arg, ".foo")
 })
 
 test_that("stop_bad_length() constructs error message", {
   expect_error(stop_bad_length(1:3, 10), "Vector must have length 10, not 3")
   expect_error(stop_bad_length(1:3, 10, arg = ".foo"), "`.foo` must have length 10, not 3")
-  expect_error(stop_bad_length(1:3, 10, actual = 100, arg = ".foo"), "`.foo` must have length 10, not 100")
-  expect_error(stop_bad_length(1:3, 10, actual = 100, arg = ".foo", what = "This thing"), "This thing must have length 10, not 100")
+  expect_error(stop_bad_length(1:3, 10, arg = ".foo", what = "This thing"), "This thing must have length 10, not 3")
 })
 
 test_that("stop_bad_element_length() constructs error message", {

--- a/tests/testthat/test-conditions.R
+++ b/tests/testthat/test-conditions.R
@@ -46,3 +46,11 @@ test_that("stop_bad_element_type() constructs type errors", {
     "purrr_error_bad_element_type"
   )
 })
+
+test_that("stop_bad_element_type() accepts `what`", {
+  expect_error(
+    stop_bad_element_type(1:3, 3, "a foobaz", what = "Result"),
+    "Result 3 must be a foobaz, not an integer vector",
+    "purrr_error_bad_element_type"
+  )
+})

--- a/tests/testthat/test-flatten.R
+++ b/tests/testthat/test-flatten.R
@@ -7,7 +7,7 @@ test_that("input must be a list", {
 
 test_that("contents of list must be supported types", {
   expect_error(flatten(list(quote(a))), "Element 1 of `.x` must be a vector, not a symbol")
-  expect_error(flatten(list(expression(a))), "Element 1 must be a vector, not an expression vector")
+  expect_error(flatten(list(expression(a))), "Element 1 of `.x` must be a vector, not an expression vector")
 })
 
 test_that("each second level element becomes first level element", {
@@ -20,6 +20,8 @@ test_that("can flatten all atomic vectors", {
   expect_equal(flatten(list(1L)), list(1L))
   expect_equal(flatten(list(1)), list(1))
   expect_equal(flatten(list("a")), list("a"))
+  expect_equal(flatten(list(as.raw(1))), list(as.raw(1)))
+  expect_equal(flatten(list(1i)), list(1i))
   expect_equal(flatten_raw(list(as.raw(1))), as.raw(1))
 })
 

--- a/tests/testthat/test-map_n.R
+++ b/tests/testthat/test-map_n.R
@@ -6,7 +6,7 @@ test_that("input must be a list of vectors", {
 })
 
 test_that("elements must be same length", {
-  expect_error(pmap(list(1:2, 1:3), identity), "Element 1 of `.l` must have length 1 or 2, not 3")
+  expect_error(pmap(list(1:2, 1:3), identity), "Element 1 of `.l` must have length 1 or 3, not 2")
 })
 
 test_that("handles any length 0 input", {

--- a/tests/testthat/test-map_n.R
+++ b/tests/testthat/test-map_n.R
@@ -1,7 +1,7 @@
 context("pmap")
 
 test_that("input must be a list of vectors", {
-  expect_error(pmap(environment(), identity), "`.x` must be a list, not an environment")
+  expect_error(pmap(environment(), identity), "`.l` must be a list, not an environment")
   expect_error(pmap(list(environment()), identity), "Element 1 of `.l` must be a vector, not an environment")
 })
 

--- a/tests/testthat/test-pluck.R
+++ b/tests/testthat/test-pluck.R
@@ -43,7 +43,7 @@ test_that("can pluck by name and position", {
 
 test_that("require length 1 vectors", {
   expect_error(pluck(1, letters), "must have length 1")
-  expect_error(pluck(1, TRUE), "must be a character or numeric")
+  expect_error(pluck(1, TRUE), "Index 1 must be a character or numeric vector")
 })
 
 test_that("special indexes never match", {

--- a/tests/testthat/test-pluck.R
+++ b/tests/testthat/test-pluck.R
@@ -152,8 +152,8 @@ test_that("attr_getter() uses exact (non-partial) matching", {
 # environments ------------------------------------------------------------
 
 test_that("pluck errors with invalid indices", {
-  expect_error(pluck(environment(), 1), "must be a string")
-  expect_error(pluck(environment(), letters), "must be a string")
+  expect_error(pluck(environment(), 1), "Index 1 must be a single string, not a single double")
+  expect_error(pluck(environment(), letters), "Index 1 must be a single string, not a character vector of length 26")
 })
 
 test_that("pluck returns missing with missing index", {

--- a/tests/testthat/test-pluck.R
+++ b/tests/testthat/test-pluck.R
@@ -174,8 +174,8 @@ newA <- methods::setClass("A", list(a = "numeric", b = "numeric"))
 A <- newA(a = 1, b = 10)
 
 test_that("pluck errors with invalid indices", {
-  expect_error(pluck(A, 1), "must be a string")
-  expect_error(pluck(A, letters), "must be a string")
+  expect_error(pluck(A, 1), "Index 1 must be a single string, not a single double")
+  expect_error(pluck(A, letters), "Index 1 must be a single string, not a character vector of length 26")
 })
 
 test_that("pluck returns missing with missing index", {


### PR DESCRIPTION
Common parameters of `stop_` functions:

* `x` as first argument, the actual faulty value. This value is used to obtain the actual length or ptype if need.

* An optional `what` argument that is used to introduce the faulty value. It should be capitalised as it starts the error message. For instance supplying `"Object"` (the default) creates an error message starting with `"Object must be"`.

* An optional `arg` argument to specify from which argument name the faulty value comes. It is used to construct the default `what` value, if not supplied. E.g. `` "`.foo` must be..." ``.


Specific parameters:

* `stop_bad_type()` takes expected and actual type as friendly type descriptors. This gives it the necessary flexibility to be a base error type for the other errors.

  ```r
  stop_bad_type(list(), "a quux", actual = "a foobaz", arg = ".foo")
  #> Error: `.foo` must be a quux, not a foobaz
  ```

* `stop_bad_length()` takes `expected_length` and `.recycle` arguments. The parameters are prefixed with `.` when they are not included in the error object. Both these parameters are used to construct appropriate error messages:

  ```r
  stop_bad_length(1:3, 10)
  #> Error: Vector must have length 10, not 3

  stop_bad_length(1:3, 10, .recycle = TRUE, arg = ".foo")
  #> Error: `.foo` must have length 1 or 10, not 3
  ```

* `stop_bad_vector()` takes `expected_ptype`, and `expected_length`. The ptype is used with `friendly_type_of()` and the new `friendly_element_type_of()` function to construct appropriate error messages:

  ```r
  stop_bad_vector(1:3, character(), 10)
  #> Error: Vector must be a character vector of length 10, not an integer vector of length 3

  stop_bad_vector(1, character(), 1)
  #> Error: Vector must be a single string, not a single double

  stop_bad_vector(factor(c("a", "b")), character(), 1)
  #> Error: Vector must be a single string, not a vector of class `factor` and of length 2
  ```

* All these throwers have "element" variants which take an `index` argument. For these variants, `what` describes the container:

  ```r
  stop_bad_element_type(1:3, 1, "a foobaz")
  #> Error: Element 1 must be a foobaz, not an integer vector

  stop_bad_element_length(1:3, 2, expected_length = 1, what = "Index")
  #> Error: Index 2 must have length 1, not 3

  stop_bad_element_vector(1:3, 3, expected_ptype = character(), expected_length = 10, arg = ".foo")
  #> Error: Element 3 of `.foo` must be a character vector of length 10, not an integer vector of length 3
  ```
