### PR TITLE
Replace data_frame with tibble

### DIFF
--- a/R/reduce.R
+++ b/R/reduce.R
@@ -401,7 +401,7 @@ seq_len2 <- function(start, end) {
 #' rerun(5, rnorm(100)) %>%
 #'   set_names(paste0("sim", 1:5)) %>%
 #'   map(~ accumulate(., ~ .05 + .x + .y)) %>%
-#'   map_dfr(~ data_frame(value = .x, step = 1:100), .id = "simulation") %>%
+#'   map_dfr(~ tibble(value = .x, step = 1:100), .id = "simulation") %>%
 #'   ggplot(aes(x = step, y = value)) +
 #'     geom_line(aes(color = simulation)) +
 #'     ggtitle("Simulations of a random walk with drift")

--- a/man/accumulate.Rd
+++ b/man/accumulate.Rd
@@ -140,7 +140,7 @@ library(ggplot2)
 rerun(5, rnorm(100)) \%>\%
   set_names(paste0("sim", 1:5)) \%>\%
   map(~ accumulate(., ~ .05 + .x + .y)) \%>\%
-  map_dfr(~ data_frame(value = .x, step = 1:100), .id = "simulation") \%>\%
+  map_dfr(~ tibble(value = .x, step = 1:100), .id = "simulation") \%>\%
   ggplot(aes(x = step, y = value)) +
     geom_line(aes(color = simulation)) +
     ggtitle("Simulations of a random walk with drift")


### PR DESCRIPTION
This PR replaces a call of `data_frame` (deprecated) with `tibble`.