### PR TITLE
adds insistently to the "adverbs" reference for pkgdown site

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -91,6 +91,7 @@ reference:
   - negate
   - partial
   - safely
+  - insistently
 
 - title: Misc
   contents:


### PR DESCRIPTION
all this does is add an entry for `insistently` to the adverbs section of the function-reference