### PR TITLE
Fix missing topics on the reference index

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -46,14 +46,12 @@ reference:
     `modify()` modifies "in place", returning a vector the same type as `.x`;
     `map2()` iterates over two vectors in parallel;
     `pmap()` (parallel map) iterates over a list of vectors;
-    `imap()` (index map) is a shortcut for the common pattern `map2(x, names(x))`;
-    `invoke()` calls each function in a list.
+    `imap()` (index map) is a shortcut for the common pattern `map2(x, names(x))`.
   contents:
   - map2
   - starts_with("modify")
   - starts_with("imap")
   - starts_with("lmap")
-  - starts_with("invoke")
 
 - title: Predicate functionals
   desc: >

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -67,6 +67,15 @@ reference:
   - negate
   - prepend
 
+- title: Plucking
+  desc: >
+    Getting or setting a single element.
+  contents:
+  - pluck
+  - modify_in
+  - attr_getter
+  - "`%@%`"
+
 - title: Other vector transforms
   desc: >
     A grab bag of useful tools for manipulating vectors.
@@ -94,7 +103,6 @@ reference:
 - title: Misc
   contents:
   - "`%||%`"
-  - "`%@%`"
   - array_tree
   - as_vector
   - rbernoulli

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -99,6 +99,8 @@ reference:
   - partial
   - safely
   - insistently
+  - rate_sleep
+  - rate-helpers
 
 - title: Misc
   contents:

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -49,7 +49,7 @@ reference:
     `imap()` (index map) is a shortcut for the common pattern `map2(x, names(x))`.
   contents:
   - map2
-  - starts_with("modify")
+  - modify
   - starts_with("imap")
   - starts_with("lmap")
 


### PR DESCRIPTION
It seems some topics are missing: https://purrr.tidyverse.org/reference/index.html

Actually, I see these warnings when running `pkgdown::build_reference()`. Some functions are reexported from rlang, so we can ignore. But, others are not ignorable.

``` r
Warning: In '_pkgdown.yml', topic must match a function or concept.
Problem topic: `starts_with("invoke")`
Warning: Topics missing from index: attr_getter, done, exec, pluck, rate-helpers, rate_sleep, rep_along, zap
```

This PR fixes:

- Remove `invoke` as it is now marked as `internal` due to deprecation
- Add missing topics
- Move `modify_in()` from "Map Variants" section

I'm not sure "Plucking" is the right title for the section. Any suggestions...?