### PR TITLE
Do not allow modify2() to recycle the first argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # purrr 0.3.0.9000
 
+* `modify2()` and `imodify()` now don't recycle the first argument, so the
+  result always has the same type as the input object (@yutannihilation,
+  #632).
 
 # purrr 0.3.0
 

--- a/R/modify.R
+++ b/R/modify.R
@@ -327,8 +327,7 @@ modify2 <- function(.x, .y, .f, ...) {
 modify2.default <- function(.x, .y, .f, ...) {
   .f <- as_mapper(.f, ...)
 
-  args <- recycle_args(list(.x, .y))
-  .x <- args[[1]]
+  args <- recycle_args(list(.x, .y), n = length(.x))
   .y <- args[[2]]
 
   for (i in seq_along(.x)) {
@@ -362,8 +361,7 @@ modify2.logical  <- function(.x, .y, .f, ...) {
 }
 
 modify_base <- function(mapper, .x, .y, .f, ...) {
-  args <- recycle_args(list(.x, .y))
-  .x <- args[[1]]
+  args <- recycle_args(list(.x, .y), n = length(.x))
   .y <- args[[2]]
 
   .x[] <- mapper(.x, .y, .f, ...)

--- a/R/utils.R
+++ b/R/utils.R
@@ -37,9 +37,11 @@ at_selection <- function(nm, .at){
   .at
 }
 
-recycle_args <- function(args) {
+recycle_args <- function(args, n = NULL) {
   lengths <- map_int(args, length)
-  n <- max(lengths)
+  if (is.null(n)) {
+    n <- max(lengths)
+  }
 
   stopifnot(all(lengths == 1L | lengths == n))
   to_recycle <- lengths == 1L

--- a/tests/testthat/test-modify.R
+++ b/tests/testthat/test-modify.R
@@ -69,6 +69,10 @@ test_that("modify2() and imodify() preserve type of first input", {
   y <- c(TRUE, FALSE)
   expect_identical(modify2(x, y, ~ if (.y) .x else 0L), c(foo = 1L, bar = 0L))
 
+  # do not recycle 1-length object (#632)
+  x <- data.frame(x = 1)
+  expect_identical(modify2(x, 1, ~ .x), x)
+
   out <- imodify(mtcars, paste)
   expect_is(out, "data.frame")
   expect_identical(out$vs, paste(mtcars$vs, "vs"))
@@ -76,9 +80,12 @@ test_that("modify2() and imodify() preserve type of first input", {
 
 test_that("modify2() recycles arguments", {
   expect_identical(modify2(1:3, 1L, `+`), int(2, 3, 4))
-  expect_identical(modify2(1, 1:3, `+`), dbl(2, 3, 4))
+  expect_identical(modify2(dbl(1:3), 1L, `+`), dbl(2, 3, 4))
   expect_identical(modify2(mtcars, seq_along(mtcars), `+`)$carb, mtcars$carb + ncol(mtcars))
   expect_identical(modify2(mtcars, 1, `+`)$carb, mtcars$carb + 1L)
+
+  # do not recycle first argument (#632)
+  expect_error(modify2(1, 1:3, `+`))
 })
 
 test_that("modify_if() requires predicate functions", {


### PR DESCRIPTION
Fix #632 

Currently, `modify2()` recycles the first argument when it is 1-length object, so the result is no more have the original class and attributes. This PR makes `recycle_args()` more strict to prevent such unexpected results.