### PR TITLE
Corrected spelling of "invocation"

### DIFF
--- a/R/partial.R
+++ b/R/partial.R
@@ -49,7 +49,7 @@
 #'
 #'
 #' # The evaluation of arguments normally occurs "lazily". Concretely,
-#' # this means that arguments are repeatedly evaluated across invokations:
+#' # this means that arguments are repeatedly evaluated across invocations:
 #' f <- partial(runif, n = rpois(1, 5))
 #' f
 #' f()

--- a/man/partial.Rd
+++ b/man/partial.Rd
@@ -59,7 +59,7 @@ try(my_mean(1:10))
 
 
 # The evaluation of arguments normally occurs "lazily". Concretely,
-# this means that arguments are repeatedly evaluated across invokations:
+# this means that arguments are repeatedly evaluated across invocations:
 f <- partial(runif, n = rpois(1, 5))
 f
 f()


### PR DESCRIPTION
Conflicted about this, "invocations" is technically the correct spelling, but I feel "invokation" more heavily relates to "invoke" and looks less dungeons-and-dragons.