### PR TITLE
Skip dplyr-related tests if unavailable.

### DIFF
--- a/tests/testthat/test-flatten.R
+++ b/tests/testthat/test-flatten.R
@@ -77,6 +77,7 @@ test_that("preserves inner names", {
 # data frame flatten ------------------------------------------------------
 
 test_that("can flatten to a data frame with named lists", {
+  skip_if_not_installed("dplyr")
   expect_is(flatten_dfr(list(c(a = 1), c(b = 2))), "data.frame")
   expect_equal(flatten_dfc(list(1)), tibble::tibble(V1 = 1))
 })

--- a/tests/testthat/test-imap.R
+++ b/tests/testthat/test-imap.R
@@ -19,6 +19,7 @@ test_that("atomic vector imap works", {
 })
 
 test_that("data frame imap works", {
+  skip_if_not_installed("dplyr")
   expect_identical(imap_dfc(x, paste), imap_dfr(x, paste))
 })
 

--- a/tests/testthat/test-map.R
+++ b/tests/testthat/test-map.R
@@ -61,6 +61,7 @@ test_that("map forces arguments in same way as base R", {
 })
 
 test_that("row and column binding work", {
+  skip_if_not_installed("dplyr")
   mtcar_mod <- mtcars %>%
     split(.$cyl) %>%
     map(~ lm(mpg ~ wt, data = .x))

--- a/tests/testthat/test-map_n.R
+++ b/tests/testthat/test-map_n.R
@@ -47,6 +47,11 @@ test_that("outputs are suffixes have correct type", {
   expect_is(pmap_dbl(list(x), mean), "numeric")
   expect_is(pmap_chr(list(x), paste), "character")
   expect_is(pmap_raw(list(x), as.raw), "raw")
+})
+
+test_that("outputs are suffixes have correct type for data frames", {
+  skip_if_not_installed("dplyr")
+  x <- 1:3
   expect_is(pmap_dfr(list(x), as.data.frame), "data.frame")
   expect_is(pmap_dfc(list(x), as.data.frame), "data.frame")
 })

--- a/tests/testthat/test-retired-invoke.R
+++ b/tests/testthat/test-retired-invoke.R
@@ -33,7 +33,12 @@ test_that("invoke_map() works with bare function", {
   expect_identical(invoke_map_lgl(`&&`, data), c(TRUE, TRUE))
 
   expect_identical(invoke_map_raw(identity, as.raw(1:3)), as.raw(1:3))
+})
 
+test_that("invoke_map() works with bare function with data frames", {
+  skip_if_not_installed("dplyr")
+
+  data <- list(1:2, 3:4)
   ops <- set_names(c(`+`, `-`), c("a", "b"))
   expect_identical(invoke_map_dfr(ops, data), invoke_map_dfc(ops, data))
 })


### PR DESCRIPTION
Tests are currently skipped that need `tidyselect`, but `dplyr` is also optional and not yet skipped.

Since `dplyr` now depends on `tidyselect`, this makes it difficult to bootstrap packages and run tests (at least for non-optional things).