### PR TITLE
Fix `compose()` with generics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # purrr 0.3.0.9000
 
+* `compose()` now works with generic functions again (#629, #639). Its
+  set of unit tests was expanded to cover many edge cases.
+
 
 # purrr 0.3.0
 

--- a/R/compose.R
+++ b/R/compose.R
@@ -48,19 +48,21 @@ compose <- function(..., .dir = c("backward", "forward")) {
     fns <- fns[-1]
   }
 
-  body <- expr({
-    out <- !!fn_body(first_fn)
+  composed <- function() {
+    call <- sys.call()
+    call[[1]] <- first_fn
+    out <- eval_bare(call, caller_env())
 
-    fns <- !!fns
     for (fn in fns) {
       out <- fn(out)
     }
 
     out
-  })
+  }
+  formals(composed) <- formals(first_fn)
 
   structure(
-    new_function(formals(first_fn), body, fn_env(first_fn)),
+    composed,
     class = c("purrr_function_compose", "function"),
     first_fn = first_fn,
     fns = fns

--- a/R/compose.R
+++ b/R/compose.R
@@ -49,12 +49,14 @@ compose <- function(..., .dir = c("backward", "forward")) {
   }
 
   composed <- function() {
+    frame <- caller_env()
+
     call <- sys.call()
     call[[1]] <- first_fn
-    out <- eval_bare(call, caller_env())
+    out <- eval_bare(call, frame)
 
     for (fn in fns) {
-      out <- fn(out)
+      out <- eval_bare(call2(fn, out), frame)
     }
 
     out

--- a/R/compose.R
+++ b/R/compose.R
@@ -53,10 +53,10 @@ compose <- function(..., .dir = c("backward", "forward")) {
 
     call <- sys.call()
     call[[1]] <- first_fn
-    out <- eval_bare(call, frame)
+    out <- .Call(purrr_eval, call, frame)
 
     for (fn in fns) {
-      out <- eval_bare(call2(fn, out), frame)
+      out <- .Call(purrr_eval, call2(fn, out), frame)
     }
 
     out

--- a/R/compose.R
+++ b/R/compose.R
@@ -49,17 +49,20 @@ compose <- function(..., .dir = c("backward", "forward")) {
   }
 
   composed <- function() {
-    frame <- caller_env()
+    env <- env(caller_env(), `_fn` = first_fn)
 
-    call <- sys.call()
-    call[[1]] <- first_fn
-    out <- .Call(purrr_eval, call, frame)
+    first_call <- sys.call()
+    first_call[[1]] <- quote(`_fn`)
+    env$`_out` <- .Call(purrr_eval, first_call, env)
+
+    call <- quote(`_fn`(`_out`))
 
     for (fn in fns) {
-      out <- .Call(purrr_eval, call2(fn, out), frame)
+      env$`_fn` <- fn
+      env$`_out` <- .Call(purrr_eval, call, env)
     }
 
-    out
+    env$`_out`
   }
   formals(composed) <- formals(first_fn)
 

--- a/src/init.c
+++ b/src/init.c
@@ -22,6 +22,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"pmap_impl",      (DL_FUNC) &pmap_impl,      4},
     {"transpose_impl", (DL_FUNC) &transpose_impl, 2},
     {"vflatten_impl",  (DL_FUNC) &vflatten_impl,  2},
+    {"purrr_eval",     (DL_FUNC) &Rf_eval,        2},
     {NULL, NULL, 0}
 };
 

--- a/tests/testthat/test-compose.R
+++ b/tests/testthat/test-compose.R
@@ -69,20 +69,14 @@ test_that("compose() with 1 input is a noop", {
 test_that("compose() works with generic functions (#629)", {
   purrr__gen <- function(x) UseMethod("purrr__gen")
 
-  # Can pass lexical context of methods through lambdas
   local({
     purrr__gen.default <- function(x) x + 1
     expect_identical(compose(~ purrr__gen(.x))(0), 1)
     expect_identical(compose(~ purrr__gen(.x), ~ purrr__gen(.x))(0), 2)
+
+    expect_identical(compose(purrr__gen)(0), 1)
+    expect_identical(compose(purrr__gen, purrr__gen)(0), 2)
   })
-
-  # Why doesn't this work locally?
-  scoped_bindings(.env = global_env(),
-    purrr__gen.default = function(x) x + 1
-  )
-
-  expect_identical(compose(purrr__gen)(0), 1)
-  expect_identical(compose(purrr__gen, purrr__gen)(0), 2)
 })
 
 test_that("compose() works with generic functions (#639)", {

--- a/tests/testthat/test-compose.R
+++ b/tests/testthat/test-compose.R
@@ -65,3 +65,84 @@ test_that("compose() with 0 inputs returns the identity", {
 test_that("compose() with 1 input is a noop", {
   expect_identical(compose(toupper)(letters), toupper(letters))
 })
+
+test_that("compose() works with generic functions (#629)", {
+  purrr__gen <- function(x) UseMethod("purrr__gen")
+
+  # Can pass lexical context of methods through lambdas
+  local({
+    purrr__gen.default <- function(x) x + 1
+    expect_identical(compose(~ purrr__gen(.x))(0), 1)
+    expect_identical(compose(~ purrr__gen(.x), ~ purrr__gen(.x))(0), 2)
+  })
+
+  # Why doesn't this work locally?
+  scoped_bindings(.env = global_env(),
+    purrr__gen.default = function(x) x + 1
+  )
+
+  expect_identical(compose(purrr__gen)(0), 1)
+  expect_identical(compose(purrr__gen, purrr__gen)(0), 2)
+})
+
+test_that("compose() works with generic functions (#639)", {
+  n_unique <- purrr::compose(length, unique)
+  expect_identical(n_unique(iris$Species), 3L)
+})
+
+test_that("compose() works with argument matching functions", {
+  # They inspect their dynamic context via sys.function()
+  fn <- function(x = c("foo", "bar")) match.arg(x)
+  expect_identical(compose(fn)("f"), "foo")
+  expect_identical(compose(fn, fn)("f"), "foo")
+})
+
+test_that("compose() works with non-local exits", {
+  fn <- function(x) return(x)
+  expect_identical(compose(fn)("foo"), "foo")
+  expect_identical(compose(fn, fn)("foo"), "foo")
+  expect_identical(compose(~ return(paste(.x, "foo")), ~ return("bar"))(), "bar foo")
+})
+
+test_that("compose() preserves lexical environment", {
+  fn <- local({
+    `_foo` <- "foo"
+    function(...) `_foo`
+  })
+  expect_identical(compose(fn)(), "foo")
+  expect_identical(compose(fn, fn)(), "foo")
+})
+
+test_that("compose() can take dots from multiple environments", {
+  f <- function(...) {
+    `_foo` <- "foo"
+    g(`_foo`, ...)
+  }
+  g <- function(...) {
+    `_bar` <- "bar"
+    h(`_bar`, ...)
+  }
+  h <- function(...) {
+    `_baz` <- "baz"
+    fn(`_baz`, ...)
+  }
+  `_quux` <- "quux"
+
+  # By value
+  fn <- compose(function(...) c(...))
+  expect_identical(f(`_quux`), c("baz", "bar", "foo", "quux"))
+
+  # By expression (base)
+  fn <- compose(function(...) substitute(...()))
+  expect_identical(f(`_quux`), as.pairlist(exprs(`_baz`, `_bar`, `_foo`, `_quux`)))
+
+  # By expression (rlang)
+  fn <- compose(function(...) enquos(...))
+  quos <- f(`_quux`)
+
+  frame <- current_env()
+  expect_true(is_reference(quo_get_env(quos[[4]]), frame))
+  expect_false(is_reference(quo_get_env(quos[[3]]), frame))
+
+  expect_identical(unname(map_chr(quos, as_name)), c("_baz", "_bar", "_foo", "_quux"))
+})

--- a/tests/testthat/test-compose.R
+++ b/tests/testthat/test-compose.R
@@ -140,3 +140,7 @@ test_that("compose() can take dots from multiple environments", {
 
   expect_identical(unname(map_chr(quos, as_name)), c("_baz", "_bar", "_foo", "_quux"))
 })
+
+test_that("compose() does not inline functions in call stack", {
+  expect_identical(compose(~ sys.call())(), quote(`_fn`()))
+})


### PR DESCRIPTION
And expand the test set to cover many edge cases.

I think `compose()` should now be the recommended way of creating function operators. For instance there are many bugs in the current version of `negate()` which doesn't work with generic functions or functions with explicit `return()`. This will all be fixed by using this implementation which also looks much cleaner:

```r
negate <- function(.p) {
  compose(`!`, as_mapper(.p))
}

negate(is.null)
#> <composed>
#> 1. function (x)
#> .Primitive("is.null")(x)
#>
#> 2. function(.x) !.x
#> <bytecode: 0x7fdb02676d28>
#> <environment: 0x7fdb0303ae78>
```

Using `compose()` to create function operators gives all of these for free:

* The signature of the new function matches the signature of the modified function. This means auto-completion in IDEs.
* Nice `print()` method that shows the different steps of the composition.
* Works with generic functions and dispatches correctly to local methods.
* Works with functions that inspect their immediate dynamic environment, for instance with `match.arg()`.
* Works with multiple levels of arguments passed through dots, both by value and by expression.