### PR TITLE
Fix `prepend()` with empty list

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,8 @@
 * `compose()` now works with generic functions again (#629, #639). Its
   set of unit tests was expanded to cover many edge cases.
 
+* `prepend()` now works with empty lists (@czeildi, #637)
+
 
 # purrr 0.3.0
 

--- a/R/prepend.R
+++ b/R/prepend.R
@@ -7,7 +7,8 @@
 #'
 #' @param x the vector to be modified.
 #' @param values to be included in the modified vector.
-#' @param before a subscript, before which the values are to be appended.
+#' @param before a subscript, before which the values are to be appended. If
+#'   `NULL`, values will be appended at the beginning even for `x` of length 0.
 #' @return A merged vector.
 #' @export
 #' @examples
@@ -16,11 +17,12 @@
 #' x %>% append("a")
 #' x %>% prepend("a")
 #' x %>% prepend(list("a", "b"), before = 3)
-prepend <- function(x, values, before = 1) {
+#' prepend(list(), x)
+prepend <- function(x, values, before = NULL) {
   n <- length(x)
-  stopifnot(before > 0 && before <= n)
+  stopifnot(is.null(before) || (before > 0 && before <= n))
 
-  if (before == 1) {
+  if (is.null(before) || before == 1) {
     c(values, x)
   } else {
     c(x[1:(before - 1)], values, x[before:n])

--- a/man/prepend.Rd
+++ b/man/prepend.Rd
@@ -4,14 +4,15 @@
 \alias{prepend}
 \title{Prepend a vector}
 \usage{
-prepend(x, values, before = 1)
+prepend(x, values, before = NULL)
 }
 \arguments{
 \item{x}{the vector to be modified.}
 
 \item{values}{to be included in the modified vector.}
 
-\item{before}{a subscript, before which the values are to be appended.}
+\item{before}{a subscript, before which the values are to be appended. If
+\code{NULL}, values will be appended at the beginning even for \code{x} of length 0.}
 }
 \value{
 A merged vector.
@@ -28,4 +29,5 @@ x <- as.list(1:3)
 x \%>\% append("a")
 x \%>\% prepend("a")
 x \%>\% prepend(list("a", "b"), before = 3)
+prepend(list(), x)
 }

--- a/tests/testthat/test-prepend.R
+++ b/tests/testthat/test-prepend.R
@@ -13,3 +13,27 @@ test_that("prepend is clearer version of merging with c()", {
     }
   )
 })
+
+test_that("prepend appends at the beginning for empty list by default", {
+  x <- list()
+  expect_identical(
+    x %>% prepend(1),
+    x %>% c(1, .)
+  )
+})
+
+test_that("prepend throws error if before param is neither NULL nor between 1 and length(x)", {
+  expect_error(
+    prepend(list(), 1, before = 1),
+    "is.null(before) || (before > 0 && before <= n) is not TRUE"
+  )
+  x <- as.list(1:3)
+  expect_error(
+    x %>% prepend(4, before = 0),
+    "is.null(before) || (before > 0 && before <= n) is not TRUE"
+  )
+  expect_error(
+    x %>% prepend(4, before = 4),
+    "is.null(before) || (before > 0 && before <= n) is not TRUE"
+  )
+})


### PR DESCRIPTION
- changes default value for `before` argument from 1 to `NULL`
- behaviour is identical for non-empty list
- by default now appends at the beginning for empty list instead throwing an error
- if before is not NULL, still throws error for empty list
- error message now includes NULL check for all cases

Fixes #637