### PR TITLE
fixed typo, added brackets

### DIFF
--- a/R/flatten.R
+++ b/R/flatten.R
@@ -4,8 +4,8 @@
 #' [unlist()], but they only ever remove a single layer of hierarchy and they
 #' are type-stable, so you always know what the type of the output is.
 #'
-#' @param .x A list of flatten. The contents of the list can be anything for
-#'   `flatten` (as a list is returned), but the contents must match the
+#' @param .x A list to flatten. The contents of the list can be anything for
+#'   `flatten()` (as a list is returned), but the contents must match the
 #'   type for the other functions.
 #' @return `flatten()` returns a list, `flatten_lgl()` a logical
 #'   vector, `flatten_int()` an integer vector, `flatten_dbl()` a

--- a/man/flatten.Rd
+++ b/man/flatten.Rd
@@ -29,8 +29,8 @@ flatten_dfr(.x, .id = NULL)
 flatten_dfc(.x)
 }
 \arguments{
-\item{.x}{A list of flatten. The contents of the list can be anything for
-\code{flatten} (as a list is returned), but the contents must match the
+\item{.x}{A list to flatten. The contents of the list can be anything for
+\code{flatten()} (as a list is returned), but the contents must match the
 type for the other functions.}
 
 \item{.id}{Either a string or \code{NULL}. If a string, the output will contain


### PR DESCRIPTION
"A list of flatten" -> "A list to flatten", and `flatten` -> `flatten()`