### PR TITLE
remove additional indefinite article in error message of `partial`

### DIFF
--- a/R/partial.R
+++ b/R/partial.R
@@ -89,7 +89,7 @@ partial <- function(.f,
       as_closure(.f),
     closure =
       .f,
-    abort(sprintf("`.f` must be a function, not a %s", friendly_type_of(.f)))
+    abort(sprintf("`.f` must be a function, not %s", friendly_type_of(.f)))
   )
 
   if (!is_null(.env)) {


### PR DESCRIPTION
fixes issue #696 (additional indefinite article **a** in example below):

``` r
library(purrr)
test_path <- "C:"
partial(file.path(test_path))
#> `.f` must be a function, not a a character vector
```
