### PR TITLE
Improves list_along documentation

### DIFF
--- a/R/along.R
+++ b/R/along.R
@@ -1,19 +1,19 @@
-#' Helper to create a new empty list of a given length.
+#' Create a list of given length
 #'
 #' @description
 #'
 #' \Sexpr[results=rd, stage=render]{purrr:::lifecycle("questioning")}
 #'
-#' It can be useful to create empty lists that you later fill through iterate.
-#' This is similar to the idea of [seq_along()], which creates a vector of the
-#' same length as its input.
+#' It can be useful to create an empty list that you plant to fill later. This is
+#' similar to the idea of [seq_along()], which creates a vector of the same
+#' length as its input.
 #'
 #' @details
 #'
 #' This function might change to [vctrs::vec_init()].
 #'
 #' @param x A vector.
-#' @return A vector of the same length as `x`.
+#' @return A list of the same length as `x`.
 #' @keywords internal
 #' @examples
 #' x <- 1:5
@@ -25,4 +25,3 @@
 list_along <- function(x) {
   vector("list", length(x))
 }
-

--- a/R/along.R
+++ b/R/along.R
@@ -1,23 +1,28 @@
-#' Helper to create vectors with matching length.
+#' Helper to create a new empty list of a given length.
 #'
-#' These functions take the idea of [seq_along()] and generalise
-#' it to creating lists (`list_along`) and repeating values
-#' (`rep_along`).
+#' @description
+#'
+#' \Sexpr[results=rd, stage=render]{purrr:::lifecycle("questioning")}
+#'
+#' It can be useful to create empty lists that you later fill through iterate.
+#' This is similar to the idea of [seq_along()], which creates a vector of the
+#' same length as its input.
+#'
+#' @details
+#'
+#' This function might change to [vctrs::vec_init()].
 #'
 #' @param x A vector.
-#' @param y Values to repeat.
 #' @return A vector of the same length as `x`.
 #' @keywords internal
 #' @examples
 #' x <- 1:5
-#' rep_along(x, 1:2)
-#' rep_along(x, 1)
+#' seq_along(x)
 #' list_along(x)
 #' @name along
-NULL
-
-#' @export
 #' @rdname along
+#' @export
 list_along <- function(x) {
   vector("list", length(x))
 }
+

--- a/man/along.Rd
+++ b/man/along.Rd
@@ -3,27 +3,29 @@
 \name{along}
 \alias{along}
 \alias{list_along}
-\title{Helper to create vectors with matching length.}
+\title{Helper to create a new empty list of a given length.}
 \usage{
 list_along(x)
 }
 \arguments{
 \item{x}{A vector.}
-
-\item{y}{Values to repeat.}
 }
 \value{
 A vector of the same length as \code{x}.
 }
 \description{
-These functions take the idea of \code{\link[=seq_along]{seq_along()}} and generalise
-it to creating lists (\code{list_along}) and repeating values
-(\code{rep_along}).
+\Sexpr[results=rd, stage=render]{purrr:::lifecycle("questioning")}
+
+It can be useful to create empty lists that you later fill through iterate.
+This is similar to the idea of \code{\link[=seq_along]{seq_along()}}, which creates a vector of the
+same length as its input.
+}
+\details{
+This function might change to \code{\link[vctrs:vec_init]{vctrs::vec_init()}}.
 }
 \examples{
 x <- 1:5
-rep_along(x, 1:2)
-rep_along(x, 1)
+seq_along(x)
 list_along(x)
 }
 \keyword{internal}

--- a/man/along.Rd
+++ b/man/along.Rd
@@ -3,7 +3,7 @@
 \name{along}
 \alias{along}
 \alias{list_along}
-\title{Helper to create a new empty list of a given length.}
+\title{Create a list of given length}
 \usage{
 list_along(x)
 }
@@ -11,14 +11,14 @@ list_along(x)
 \item{x}{A vector.}
 }
 \value{
-A vector of the same length as \code{x}.
+A list of the same length as \code{x}.
 }
 \description{
 \Sexpr[results=rd, stage=render]{purrr:::lifecycle("questioning")}
 
-It can be useful to create empty lists that you later fill through iterate.
-This is similar to the idea of \code{\link[=seq_along]{seq_along()}}, which creates a vector of the
-same length as its input.
+It can be useful to create an empty list that you plant to fill later. This is
+similar to the idea of \code{\link[=seq_along]{seq_along()}}, which creates a vector of the same
+length as its input.
 }
 \details{
 This function might change to \code{\link[vctrs:vec_init]{vctrs::vec_init()}}.


### PR DESCRIPTION
Provides more details, removes mentions of `rep_along`, and adds lifecycle badge. 

Fixes #702 