### PR TITLE
Clarify what `quietly` does.

### DIFF
--- a/R/output.R
+++ b/R/output.R
@@ -17,8 +17,10 @@
 #'   an `error` object and `result` has a default value (`otherwise`).
 #'   Else `error` is `NULL`.
 #'
-#'   `quietly`: wrapped function instead returns a list with components
-#'   `result`, `output`, `messages` and `warnings`.
+#'   `quietly`: wrapped function instead returns a list with components. 
+#'   `result`, `output`, `messages` and `warnings`. This function does 
+#'   not provide error handling, instead it acts to capture what would
+#'   have been printed output.
 #'
 #'   `possibly`: wrapped function uses a default value (`otherwise`)
 #'   whenever an error occurs.


### PR DESCRIPTION
Using quietly does not provide error handling. It is grouped with functions that do, so making it clear that it does not would be beneficial. It is easy to assume it quietly handles errors for you.