### PR TITLE
dplyr 1.0.0

### DIFF
--- a/tests/testthat/test-flatten.R
+++ b/tests/testthat/test-flatten.R
@@ -84,6 +84,6 @@ test_that("can flatten to a data frame with named lists", {
   expect_is(res, "data.frame")
   expect_equal(res[[1L]], 1)
 
-  skip_if_not_installed("dplyr", minimum_version = "0.8.99.9000")
-  expect_equal(res, data.frame(...1 = 1))
+  skip_if_not_installed("dplyr", minimum_version = "0.8.99.9001")
+  expect_equal(res, tibble::tibble(...1 = 1))
 })

--- a/tests/testthat/test-flatten.R
+++ b/tests/testthat/test-flatten.R
@@ -79,5 +79,11 @@ test_that("preserves inner names", {
 test_that("can flatten to a data frame with named lists", {
   skip_if_not_installed("dplyr")
   expect_is(flatten_dfr(list(c(a = 1), c(b = 2))), "data.frame")
-  expect_equal(flatten_dfc(list(1)), tibble::tibble(V1 = 1))
+
+  res <- flatten_dfc(list(1))
+  expect_is(res, "data.frame")
+  expect_equal(res[[1L]], 1)
+
+  skip_if_not_installed("dplyr", minimum_version = "0.8.99.9000")
+  expect_equal(res, data.frame(...1 = 1))
 })


### PR DESCRIPTION
We see this as part of rev dep checks for `dplyr` 1.0.0: 

```
[master* ↓] 286.2 MiB ❯ revdepcheck::revdep_details(revdep = "purrr")
══ Reverse dependency check ═════════════════════════════════════ purrr 0.3.3 ══

Status: BROKEN

── Newly failing

✖ checking tests ...

── Before ──────────────────────────────────────────────────────────────────────
0 errors ✔ | 0 warnings ✔ | 0 notes ✔

── After ───────────────────────────────────────────────────────────────────────
❯ checking tests ...
  See below...

── Test failures ───────────────────────────────────────────────── testthat ────

> library(testthat)
> library(purrr)

Attaching package: 'purrr'

The following object is masked from 'package:testthat':

    is_null

>
> test_check("purrr")
── 1. Failure: can flatten to a data frame with named lists (@test-flatten.R#82)
flatten_dfc(list(1)) not equal to tibble::tibble(V1 = 1).
Names: 1 string mismatch
Attributes: < Component "class": Lengths (1, 3) differ (string compare on first 1) >
Attributes: < Component "class": 1 string mismatch >

── 2. Failure: data frame imap works (@test-imap.R#23)  ────────────────────────
imap_dfc(x, paste) not identical to imap_dfr(x, paste).
Attributes: < Component "class": Lengths (1, 3) differ (string compare on first 1) >
Attributes: < Component "class": 1 string mismatch >

── 3. Failure: invoke_map() works with bare function with data frames (@test-ret
invoke_map_dfr(ops, data) not identical to invoke_map_dfc(ops, data).
Attributes: < Component "class": Lengths (3, 1) differ (string compare on first 1) >
Attributes: < Component "class": 1 string mismatch >

══ testthat results  ═══════════════════════════════════════════════════════════
[ OK: 766 | SKIPPED: 0 | WARNINGS: 0 | FAILED: 3 ]
1. Failure: can flatten to a data frame with named lists (@test-flatten.R#82)
2. Failure: data frame imap works (@test-imap.R#23)
3. Failure: invoke_map() works with bare function with data frames (@test-retired-invoke.R#43)

Error: testthat unit tests failed
Execution halted

1 error ✖ | 0 warnings ✔ | 0 notes ✔
```

This pull request deals with the first test error, due to changes in what dplyr does for name repair, the test should work for both. 

The other tests fail because `bind_cols()` makes a `data.frame` when it used to make a `tibble`, i.e.: 

```
[master] 165.8 MiB ❯ callr::r(function() dplyr::bind_cols(a = 1, b = 2), libpath = "../bench-libs/0.8.3/")
# A tibble: 1 x 2
      a     b
  <dbl> <dbl>
1     1     2
[master] 165.8 MiB ❯ callr::r(function() dplyr::bind_cols(a = 1, b = 2))
  a b
1 1 2
```

This is probably something to be fixed in `dplyr`, judging by the number of `Lengths (1, 3) differ ` errors we see in the rev dep. 