### PR TITLE
Make the imap docs more consistent.

### DIFF
--- a/R/imap.R
+++ b/R/imap.R
@@ -1,6 +1,6 @@
 #' Apply a function to each element of a vector, and its index
 #'
-#' `imap_xxx(x, ...)`, an indexed map, is short hand for
+#' `imap(x, ...)`, an indexed map, is short hand for
 #' `map2(x, names(x), ...)` if `x` has names, or `map2(x, seq_along(x), ...)`
 #' if it does not. This is useful if you need to compute on both the value
 #' and the position of an element.


### PR DESCRIPTION
I think here you either need to remove the`_xxx` or add it to the `map2()` later in the sentence to make them `map2_xxx()`. Personally, I don't like the `_xxx` since the argument is also `x`.