### PR TITLE
Changes list_modify to be able to remove key-value pairs whose value is a list

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 # purrr 0.3.4
 
+* Fixed issue in `list_modify()` that prevented lists from being
+  removed with `zap()` (@adamroyjones, #777).
+
 * Added documentation for exporting functions created with purrr
   adverb (@njtierney, #668). See `?faq-adverbs-export`.
 

--- a/R/list-modify.R
+++ b/R/list-modify.R
@@ -69,9 +69,10 @@ list_recurse <- function(x, y, base_case) {
     abort("`...` arguments must be either all named, or all unnamed")
   }
 
+  # N.B. is_list(zap()) is TRUE.
   if (is_null(y_names)) {
     for (i in rev(seq_along(y))) {
-      if (i <= length(x) && is_list(x[[i]]) && is_list(y[[i]])) {
+      if (i <= length(x) && is_list(x[[i]]) && is_list(y[[i]]) && !is_zap(y[[i]])) {
         x[[i]] <- list_recurse(x[[i]], y[[i]], base_case)
       } else {
         x[[i]] <- maybe_zap(base_case(x[[i]], y[[i]]))
@@ -80,7 +81,7 @@ list_recurse <- function(x, y, base_case) {
   } else {
     for (i in seq_along(y_names)) {
       nm <- y_names[[i]]
-      if (has_name(x, nm) && is_list(x[[nm]]) && is_list(y[[i]])) {
+      if (has_name(x, nm) && is_list(x[[nm]]) && is_list(y[[i]]) && !is_zap(y[[i]])) {
         x[[nm]] <- list_recurse(x[[nm]], y[[i]], base_case)
       } else {
         x[[nm]] <- maybe_zap(base_case(x[[nm]], y[[i]]))

--- a/tests/testthat/test-list-modify-update.R
+++ b/tests/testthat/test-list-modify-update.R
@@ -16,6 +16,10 @@ test_that("unnamed lists are replaced by position", {
 test_that("can remove elements with `zap()`", {
   expect_equal(list_modify(list(1, 2, 3), zap(), zap()), list(3))
   expect_equal(list_modify(list(a = 1, b = 2, c = 3), b = zap(), a = zap()), list(c = 3))
+  expect_equal(
+    list_modify(list(a = list(fst = 1, snd = 2), b = 2, c = 3), b = zap(), a = zap()),
+    list(c = 3)
+  )
 })
 
 test_that("error if inputs are not all named or unnamed", {


### PR DESCRIPTION
The documentation to `list_modify` indicates that one should "[u]se `zap()` to remove values" from a list. This does not work in the expected way when attempting to remove a key-value pair whose value is a list:

```r
library(purrr)

list(foo = 1, bar = 2) %>% list_modify(foo = zap())

list(foo = c(1, 2), bar = 3) %>% list_modify(foo = zap())

list(foo = list(fst = 1, snd = 2), bar = 3) %>% list_modify(foo = zap())
```

The first two examples above return an object identical to `list(bar = 3)`; the third is such that the call to `list_modify` is a no-op. This pull request fixes this behaviour. It also adds a unit test to cover this case.

Issues: #776