### PR TITLE
Use vctrs to simplify `accumulate()` results

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,8 @@ Depends:
     R (>= 3.2)
 Imports: 
     magrittr (>= 1.5),
-    rlang (>= 0.3.1)
+    rlang (>= 0.4.7),
+    vctrs (>= 0.3.2)
 Suggests: 
     covr,
     crayon,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # purrr (development version)
 
+* `accumulate()` now uses vctrs for simplifying the output. This
+  ensures a more principled and flexible coercion behaviour.
+
 * Improved performance of `partial()` (#715).
 
 

--- a/R/reduce.R
+++ b/R/reduce.R
@@ -461,13 +461,14 @@ accumulate <- function(.x, .f, ..., .init, .dir = c("forward", "backward")) {
   res <- reduce_impl(.x, .f, ..., .init = .init, .dir = .dir, .acc = TRUE)
   names(res) <- accumulate_names(names(.x), .init, .dir)
 
-  # FIXME vctrs: This simplification step is for compatibility with
-  # the `base::Reduce()` implementation in earlier purrr versions
-  if (all(map_int(res, length) == 1L)) {
-    res <- unlist(res, recursive = FALSE)
+  # It would be unappropriate to simplify the result rowwise with
+  # `accumulate()` because it has invariants defined in terms of
+  # `length()` rather than `vec_size()`
+  if (some(res, is.data.frame)) {
+    res
+  } else {
+    vec_simplify(res)
   }
-
-  res
 }
 #' @rdname accumulate
 #' @export

--- a/R/utils.R
+++ b/R/utils.R
@@ -307,3 +307,17 @@ quo_invert <- function(call) {
 quo_is_constant <- function(quo) {
   is_reference(quo_get_env(quo), empty_env())
 }
+
+vec_simplify <- function(x) {
+  if (!vctrs::vec_is_list(x)) {
+    return(x)
+  }
+  if (!every(x, ~ vctrs::vec_is(.x) && vctrs::vec_size(.x) == 1L)) {
+    return(x)
+  }
+
+  tryCatch(
+    vctrs_error_incompatible_type = function(...) x,
+    vctrs::vec_c(!!!x)
+  )
+}

--- a/tests/testthat/test-reduce.R
+++ b/tests/testthat/test-reduce.R
@@ -109,6 +109,29 @@ test_that("accumulate() forces arguments (#643)", {
   expect_true(every(fns, function(f) identical(f(1), 1)))
 })
 
+test_that("accumulate() uses vctrs to simplify results", {
+  out <- list("foo", factor("bar")) %>% accumulate(~ .y)
+  expect_identical(out, c("foo", "bar"))
+})
+
+test_that("accumulate() does not fail when input can't be simplified", {
+  expect_identical(accumulate(list(1L, 2:3), ~ .y), list(1L, 2:3))
+  expect_identical(accumulate(list(1, "a"), ~ .y), list(1, "a"))
+  expect_identical(accumulate(1:3, ~ .y), 1:3)
+  expect_identical(accumulate(list(identity), ~ .y), list(identity))
+  expect_identical(accumulate(mtcars, ~ .y), as.list(mtcars))
+})
+
+test_that("accumulate() does not simplify data frame rowwise", {
+  out <- accumulate(
+    1L,
+    ~ data.frame(new = .y),
+    .init = data.frame(new = 0L)
+  )
+  exp <- list(data.frame(new = 0L), data.frame(new = 1L))
+  expect_identical(out, exp)
+})
+
 
 # reduce2 -----------------------------------------------------------------
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -76,6 +76,29 @@ test_that("quo_invert() unwraps constants", {
   expect_identical(quo_invert(call), new_quosure(quote(foo(foo, NULL)), quo_get_env(foo)))
 })
 
+test_that("vec_simplify() coerces atomic inputs", {
+  expect_identical(
+    vec_simplify(list(1, TRUE)),
+    c(1, 1)
+  )
+  expect_identical(
+    vec_simplify(list("foo", factor("bar"))),
+    c("foo", "bar")
+  )
+  expect_identical(
+    vec_simplify(list(data.frame(x = FALSE), data.frame(x = 1L))),
+    data.frame(x = 0:1)
+  )
+})
+
+test_that("vec_simplify() ignores complex inputs", {
+  expect_identical(vec_simplify(list(1L, 2:3)), list(1L, 2:3))
+  expect_identical(vec_simplify(list(1, "a")), list(1, "a"))
+  expect_identical(vec_simplify(1:3), 1:3)
+  expect_identical(vec_simplify(list(identity)), list(identity))
+  expect_identical(vec_simplify(mtcars), mtcars)
+})
+
 
 # Lifecycle ---------------------------------------------------------------
 


### PR DESCRIPTION
Draft `vec_simplify()` to simplify lists to atomic vectors when:

- All elements are vectors of size 1 as defined by vctrs
- All elements are coercible by vctrs

Use it in `accumulate()` for the simplification step. I'd rather not have `accumulate()` simplify results but it's probably too late.

Data frames can be simplified by `vec_simplify()` but this is disabled in `accumulate()` since its invariants are defined in terms of `length()`.