### PR TITLE
Use `rlang::check_installed()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Depends:
 Imports: 
     lifecycle (>= 0.2.0),
     magrittr (>= 1.5.0),
-    rlang (>= 0.4.7),
+    rlang (>= 0.4.10),
     vctrs (>= 0.3.2)
 LinkingTo:
     vctrs

--- a/R/cross.R
+++ b/R/cross.R
@@ -198,7 +198,7 @@ cross_df <- function(.l, .filter = NULL) {
     "tidyr::expand_grid()",
     details = c(i = "See <https://github.com/tidyverse/purrr/issues/768>.")
   )
-  check_tibble()
+  check_installed("tibble")
   cross(.l, .filter = .filter) %>%
     transpose() %>%
     simplify_all() %>%

--- a/R/flatten.R
+++ b/R/flatten.R
@@ -63,9 +63,7 @@ flatten_raw <- function(.x) {
 #' @export
 #' @rdname flatten
 flatten_dfr <- function(.x, .id = NULL) {
-  if (!is_installed("dplyr")) {
-    abort("`flatten_dfr()` requires dplyr")
-  }
+  check_installed("dplyr", "for `flatten_dfr()`")
 
   res <- .Call(flatten_impl, .x)
   dplyr::bind_rows(res, .id = .id)
@@ -74,9 +72,7 @@ flatten_dfr <- function(.x, .id = NULL) {
 #' @export
 #' @rdname flatten
 flatten_dfc <- function(.x) {
-  if (!is_installed("dplyr")) {
-    abort("`flatten_dfc()` requires dplyr")
-  }
+  check_installed("dplyr", "for `flatten_dfc()`")
 
   res <- .Call(flatten_impl, .x)
   dplyr::bind_cols(res)

--- a/R/flatten.R
+++ b/R/flatten.R
@@ -63,7 +63,7 @@ flatten_raw <- function(.x) {
 #' @export
 #' @rdname flatten
 flatten_dfr <- function(.x, .id = NULL) {
-  check_installed("dplyr", "for `flatten_dfr()`")
+  check_installed("dplyr", "for `flatten_dfr()`.")
 
   res <- .Call(flatten_impl, .x)
   dplyr::bind_rows(res, .id = .id)
@@ -72,7 +72,7 @@ flatten_dfr <- function(.x, .id = NULL) {
 #' @export
 #' @rdname flatten
 flatten_dfc <- function(.x) {
-  check_installed("dplyr", "for `flatten_dfc()`")
+  check_installed("dplyr", "for `flatten_dfc()`.")
 
   res <- .Call(flatten_impl, .x)
   dplyr::bind_cols(res)

--- a/R/map.R
+++ b/R/map.R
@@ -227,9 +227,7 @@ map_raw <- function(.x, .f, ...) {
 #'   Only applies to `_dfr` variant.
 #' @export
 map_dfr <- function(.x, .f, ..., .id = NULL) {
-  if (!is_installed("dplyr")) {
-    abort("`map_df()` requires dplyr")
-  }
+  check_installed("dplyr", "for `map_dfr()`")
 
   .f <- as_mapper(.f, ...)
   res <- map(.x, .f, ...)
@@ -244,9 +242,7 @@ map_df <- map_dfr
 #' @rdname map
 #' @export
 map_dfc <- function(.x, .f, ...) {
-  if (!is_installed("dplyr")) {
-    abort("`map_dfc()` requires dplyr")
-  }
+  check_installed("dplyr", "for `map_dfc()`")
 
   .f <- as_mapper(.f, ...)
   res <- map(.x, .f, ...)

--- a/R/map.R
+++ b/R/map.R
@@ -227,7 +227,7 @@ map_raw <- function(.x, .f, ...) {
 #'   Only applies to `_dfr` variant.
 #' @export
 map_dfr <- function(.x, .f, ..., .id = NULL) {
-  check_installed("dplyr", "for `map_dfr()`")
+  check_installed("dplyr", "for `map_dfr()`.")
 
   .f <- as_mapper(.f, ...)
   res <- map(.x, .f, ...)
@@ -242,7 +242,7 @@ map_df <- map_dfr
 #' @rdname map
 #' @export
 map_dfc <- function(.x, .f, ...) {
-  check_installed("dplyr", "for `map_dfc()`")
+  check_installed("dplyr", "for `map_dfc()`.")
 
   .f <- as_mapper(.f, ...)
   res <- map(.x, .f, ...)

--- a/R/map2-pmap.R
+++ b/R/map2-pmap.R
@@ -136,7 +136,7 @@ map2_raw <- function(.x, .y, .f, ...) {
 #' @rdname map2
 #' @export
 map2_dfr <- function(.x, .y, .f, ..., .id = NULL) {
-  check_installed("dplyr", "for `map2_dfr()`")
+  check_installed("dplyr", "for `map2_dfr()`.")
 
   .f <- as_mapper(.f, ...)
   res <- map2(.x, .y, .f, ...)
@@ -146,7 +146,7 @@ map2_dfr <- function(.x, .y, .f, ..., .id = NULL) {
 #' @rdname map2
 #' @export
 map2_dfc <- function(.x, .y, .f, ...) {
-  check_installed("dplyr", "for `map2_dfc()`")
+  check_installed("dplyr", "for `map2_dfc()`.")
 
   .f <- as_mapper(.f, ...)
   res <- map2(.x, .y, .f, ...)
@@ -228,7 +228,7 @@ pmap_raw <- function(.l, .f, ...) {
 #' @rdname map2
 #' @export
 pmap_dfr <- function(.l, .f, ..., .id = NULL) {
-  check_installed("dplyr", "for `pmap_dfr()`")
+  check_installed("dplyr", "for `pmap_dfr()`.")
 
   .f <- as_mapper(.f, ...)
   res <- pmap(.l, .f, ...)
@@ -238,7 +238,7 @@ pmap_dfr <- function(.l, .f, ..., .id = NULL) {
 #' @rdname map2
 #' @export
 pmap_dfc <- function(.l, .f, ...) {
-  check_installed("dplyr", "for `pmap_dfc()`")
+  check_installed("dplyr", "for `pmap_dfc()`.")
 
   .f <- as_mapper(.f, ...)
   res <- pmap(.l, .f, ...)

--- a/R/map2-pmap.R
+++ b/R/map2-pmap.R
@@ -136,20 +136,17 @@ map2_raw <- function(.x, .y, .f, ...) {
 #' @rdname map2
 #' @export
 map2_dfr <- function(.x, .y, .f, ..., .id = NULL) {
-  if (!is_installed("dplyr")) {
-    abort("`map2_dfr()` requires dplyr")
-  }
+  check_installed("dplyr", "for `map2_dfr()`")
 
   .f <- as_mapper(.f, ...)
   res <- map2(.x, .y, .f, ...)
   dplyr::bind_rows(res, .id = .id)
 }
+
 #' @rdname map2
 #' @export
 map2_dfc <- function(.x, .y, .f, ...) {
-  if (!is_installed("dplyr")) {
-    abort("`map2_dfc()` requires dplyr")
-  }
+  check_installed("dplyr", "for `map2_dfc()`")
 
   .f <- as_mapper(.f, ...)
   res <- map2(.x, .y, .f, ...)
@@ -231,9 +228,7 @@ pmap_raw <- function(.l, .f, ...) {
 #' @rdname map2
 #' @export
 pmap_dfr <- function(.l, .f, ..., .id = NULL) {
-  if (!is_installed("dplyr")) {
-    abort("`pmap_dfr()` requires dplyr")
-  }
+  check_installed("dplyr", "for `pmap_dfr()`")
 
   .f <- as_mapper(.f, ...)
   res <- pmap(.l, .f, ...)
@@ -243,9 +238,7 @@ pmap_dfr <- function(.l, .f, ..., .id = NULL) {
 #' @rdname map2
 #' @export
 pmap_dfc <- function(.l, .f, ...) {
-  if (!is_installed("dplyr")) {
-    abort("`pmap_dfc()` requires dplyr")
-  }
+  check_installed("dplyr", "for `pmap_dfc()`")
 
   .f <- as_mapper(.f, ...)
   res <- pmap(.l, .f, ...)

--- a/R/utils.R
+++ b/R/utils.R
@@ -10,28 +10,16 @@ NULL
 
 maybe_as_data_frame <- function(out, x) {
   if (is.data.frame(x)) {
-    check_tibble()
+    check_installed("tibble")
     tibble::as_tibble(out)
   } else {
     out
   }
 }
 
-check_tibble <- function() {
-  if (!is_installed("tibble")) {
-    abort("The tibble package must be installed")
-  }
-}
-
-check_tidyselect <- function(){
-  if (!is_installed("tidyselect")) {
-    abort("Using tidyselect in `map_at()` requires tidyselect")
-  }
-}
-
 at_selection <- function(nm, .at){
-  if (is_quosures(.at)){
-    check_tidyselect()
+  if (is_quosures(.at)) {
+    check_installed("tidyselect", "for using tidyselect in `map_at()`")
     .at <- tidyselect::vars_select(.vars = nm, !!!.at)
   }
   .at

--- a/R/utils.R
+++ b/R/utils.R
@@ -19,7 +19,7 @@ maybe_as_data_frame <- function(out, x) {
 
 at_selection <- function(nm, .at){
   if (is_quosures(.at)) {
-    check_installed("tidyselect", "for using tidyselect in `map_at()`")
+    check_installed("tidyselect", "for using tidyselect in `map_at()`.")
     .at <- tidyselect::vars_select(.vars = nm, !!!.at)
   }
   .at


### PR DESCRIPTION
This PR bumps the rlang requiremnt slightly to 0.4.10 and replaces the `is_installed()` + `abort()` pattern with the handy new `rlang::check_installed()`. 