### PR TITLE
Use .else in atomic modification

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,9 @@
 
 ## Features and fixes
 
+* `modify_if(.else)` is now actually evaluated for atomic vectors (@mgirlich, 
+  #701).
+   
 * `as_mapper()` is now around twice as fast when used with character,
   integer, or list (#820).
 

--- a/R/modify.R
+++ b/R/modify.R
@@ -212,29 +212,33 @@ modify.pairlist <- function(.x, .f, ...) {
 }
 
 #' @export
-modify_if.integer <- function(.x, .p, .f, ...) {
-  sel <- probe(.x, .p)
-  .x[sel] <- map_int(.x[sel], .f, ...)
-  .x
+modify_if.integer <- function(.x, .p, .f, ..., .else = NULL) {
+  modify_if_atomic(map_int, .x, .p, .true = .f, .false = .else, ...)
 }
 #' @export
-modify_if.double <- function(.x, .p, .f, ...) {
-  sel <- probe(.x, .p)
-  .x[sel] <- map_dbl(.x[sel], .f, ...)
-  .x
+modify_if.double <- function(.x, .p, .f, ..., .else = NULL) {
+  modify_if_atomic(map_dbl, .x, .p, .true = .f, .false = .else, ...)
 }
 #' @export
-modify_if.character <- function(.x, .p, .f, ...) {
-  sel <- probe(.x, .p)
-  .x[sel] <- map_chr(.x[sel], .f, ...)
-  .x
+modify_if.character <- function(.x, .p, .f, ..., .else = NULL) {
+  modify_if_atomic(map_chr, .x, .p, .true = .f, .false = .else, ...)
 }
 #' @export
-modify_if.logical <- function(.x, .p, .f, ...) {
+modify_if.logical <- function(.x, .p, .f, ..., .else = NULL) {
+  modify_if_atomic(map_lgl, .x, .p, .true = .f, .false = .else, ...)
+}
+
+modify_if_atomic <- function(.fmap, .x, .p, .true, .false = NULL, ...) {
   sel <- probe(.x, .p)
-  .x[sel] <- map_lgl(.x[sel], .f, ...)
+  .x[sel] <- .fmap(.x[sel], .true, ...)
+
+  if (!is.null(.false)) {
+    .x[!sel] <- .fmap(.x[!sel], .false, ...)
+  }
+
   .x
 }
+
 
 #' @export
 modify_at.integer <- function(.x, .at, .f, ...) {

--- a/tests/testthat/test-modify.R
+++ b/tests/testthat/test-modify.R
@@ -88,6 +88,11 @@ test_that("`.else` modifies false elements", {
   exp <- modify_if(iris, negate(is.factor), as.integer)
   exp <- modify_if(exp, is.factor, as.character)
   expect_identical(modify_if(iris, is.factor, as.character, .else = as.integer), exp)
+
+  expect_equal(modify_if(c(TRUE, FALSE), ~ .x, ~ FALSE, .else = ~ TRUE), c(FALSE, TRUE))
+  expect_equal(modify_if(1:2, ~ .x == 1, ~ 3L, .else = ~ 4L), c(3, 4))
+  expect_equal(modify_if(c(1, 10), ~ .x < 5, ~ .x * 10, .else = ~ .x / 2), c(10, 5))
+  expect_equal(modify_if(c("a", "b"), ~ .x == "a", ~ "A", .else = ~ "B"), c("A", "B"))
 })
 
 test_that("modify family preserves NULLs", {


### PR DESCRIPTION
Fixes #701. Originally implemented by @mgirlich in #724.