### PR TITLE
Make `list_flatten()` generic

### DIFF
--- a/R/list-flatten.R
+++ b/R/list-flatten.R
@@ -10,9 +10,10 @@
 #' @param name_repair One of `"minimal"`, `"unique"`, `"universal"`, or
 #'   `"check_unique"`. See [vctrs::vec_as_names()] for the meaning of these
 #'   options.
-#' @return A list. The list might be shorter if `x` contains empty lists,
-#'   the same length if it contains lists of length 1 or no sub-lists,
-#'   or longer if it contains lists of length > 1.
+#' @return A list of the same type as `x`. The list might be shorter
+#'   if `x` contains empty lists, the same length if it contains lists
+#'   of length 1 or no sub-lists, or longer if it contains lists of
+#'   length > 1.
 #' @export
 #' @examples
 #' x <- list(1, list(2, 3), list(4, list(5)))
@@ -45,11 +46,20 @@ list_flatten <- function(
   ) {
   vec_check_list(x)
 
-  x <- map_if(x, vec_is_list, identity, .else = list)
-  list_unchop(
-    x,
+  # Take the proxy as we restore on exit
+  proxy <- vec_proxy(x)
+
+  # Unclass S3 lists to avoid their coercion methods. Wrap atoms in a
+  # list of size 1 so the elements can be concatenated in a single list.
+  proxy <- map_if(proxy, vec_is_list, unclass, .else = list)
+
+  out <- list_unchop(
+    proxy,
     ptype = list(),
     name_spec = name_spec,
     name_repair = name_repair
   )
+
+  # Preserve input type
+  vec_restore(out, x)
 }

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -19,3 +19,7 @@ local_name_repair_quiet <- function(frame = caller_env()) {
 local_name_repair_verbose <- function(frame = caller_env()) {
   local_options(rlib_name_repair_verbosity = "verbose", .frame = frame)
 }
+
+local_methods <- function(..., .frame = caller_env()) {
+  local_bindings(..., .env = global_env(), .frame = .frame)
+}

--- a/tests/testthat/test-list-flatten.R
+++ b/tests/testthat/test-list-flatten.R
@@ -29,7 +29,7 @@ test_that("list_flatten() restores", {
   }
   new_my_num_list <- function(xs) {
     stopifnot(
-      purrr::every(xs, \(x) {
+      every(xs, function(x) {
         is_null(x) ||
           is.numeric(x) ||
           inherits(x, "my_num_list")

--- a/tests/testthat/test-list-flatten.R
+++ b/tests/testthat/test-list-flatten.R
@@ -30,9 +30,7 @@ test_that("list_flatten() restores", {
   new_my_num_list <- function(xs) {
     stopifnot(
       every(xs, function(x) {
-        is_null(x) ||
-          is.numeric(x) ||
-          inherits(x, "my_num_list")
+        is_null(x) || is.numeric(x) || inherits(x, "my_num_list")
       })
     )
     new_vctr(xs, class = "my_num_list")

--- a/tests/testthat/test-list-flatten.R
+++ b/tests/testthat/test-list-flatten.R
@@ -24,6 +24,7 @@ test_that("requires a list", {
 })
 
 test_that("list_flatten() restores", {
+  # This simulates a recursive list-of type
   my_num_list <- function(...) {
     new_my_num_list(list2(...))
   }

--- a/tests/testthat/test-list-flatten.R
+++ b/tests/testthat/test-list-flatten.R
@@ -22,3 +22,31 @@ test_that("can control names if both present", {
 test_that("requires a list", {
   expect_snapshot(list_flatten(1:2), error = TRUE)
 })
+
+test_that("list_flatten() restores", {
+  my_num_list <- function(...) {
+    new_my_num_list(list2(...))
+  }
+  new_my_num_list <- function(xs) {
+    stopifnot(
+      purrr::every(xs, \(x) {
+        is_null(x) ||
+          is.numeric(x) ||
+          inherits(x, "my_num_list")
+      })
+    )
+    new_vctr(xs, class = "my_num_list")
+  }
+
+  local_methods(
+    vec_restore.my_num_list = function(x, to, ...) {
+      new_my_num_list(x)
+    }
+  )
+
+  xs <- my_num_list(1, 2, my_num_list(3:4))
+  expect_equal(
+    list_flatten(xs),
+    my_num_list(1, 2, 3:4)
+  )
+})

--- a/tests/testthat/test-list-flatten.R
+++ b/tests/testthat/test-list-flatten.R
@@ -49,3 +49,26 @@ test_that("list_flatten() restores", {
     my_num_list(1, 2, 3:4)
   )
 })
+
+test_that("list_flatten() supports strict types", {
+  local_methods(
+    vec_cast.list.my_strict_list = function(x, to, ...) {
+      abort("Can't coerce to list.")
+    }
+  )
+
+  x <- structure(list(1), class = c("my_strict_list", "list"))
+
+  expect_equal(
+    list_flatten(list(x)),
+    list(1)
+  )
+})
+
+test_that("list_flatten() works with vctrs::list_of()", {
+  # Currently only with flat lists because list_of can't be recursive
+  expect_equal(
+    list_flatten(list_of(1, 2, 3)),
+    list_of(1, 2, 3)
+  )
+})


### PR DESCRIPTION
Closes r-lib/vctrs#395.

Won't be very useful until `list_of()` supports type recursion, but I think it's better to make `list_flatten()` generic now to avoid changing behaviour in the future.