### PR TITLE
Standardise `_if` & `_at` helpers

### DIFF
--- a/R/deprec-splice.R
+++ b/R/deprec-splice.R
@@ -28,7 +28,7 @@ splice <- function(...) {
 }
 
 splice_if <- function(.x, .p) {
-  unspliced <- !if_idx(.x, .p)
+  unspliced <- !where_if(.x, .p)
   out <- modify_if(.x, unspliced, list)
   list_flatten(out, name_spec = "{inner}")
 }

--- a/R/deprec-splice.R
+++ b/R/deprec-splice.R
@@ -28,7 +28,7 @@ splice <- function(...) {
 }
 
 splice_if <- function(.x, .p) {
-  unspliced <- !probe(.x, .p)
+  unspliced <- !if_idx(.x, .p)
   out <- modify_if(.x, unspliced, list)
   list_flatten(out, name_spec = "{inner}")
 }

--- a/R/keep.R
+++ b/R/keep.R
@@ -42,14 +42,14 @@
 #' list(a = "a", b = NULL, c = integer(0), d = NA, e = list()) %>%
 #'   compact()
 keep <- function(.x, .p, ...) {
-  where <- if_idx(.x, .p, ...)
+  where <- where_if(.x, .p, ...)
   .x[!is.na(where) & where]
 }
 
 #' @export
 #' @rdname keep
 discard <- function(.x, .p, ...) {
-  where <- if_idx(.x, .p, ...)
+  where <- where_if(.x, .p, ...)
   .x[is.na(where) | !where]
 }
 
@@ -75,13 +75,13 @@ compact <- function(.x, .p = identity) {
 #' x %>% keep_at(~ nchar(.x) == 3)
 #' x %>% discard_at(~ nchar(.x) == 3)
 keep_at <- function(x, at) {
-  where <- at_idx(x, at)
+  where <- where_at(x, at)
   x[where]
 }
 
 #' @export
 #' @rdname keep_at
 discard_at <- function(x, at) {
-  where <- at_idx(x, at)
+  where <- where_at(x, at)
   x[!where]
 }

--- a/R/keep.R
+++ b/R/keep.R
@@ -42,15 +42,15 @@
 #' list(a = "a", b = NULL, c = integer(0), d = NA, e = list()) %>%
 #'   compact()
 keep <- function(.x, .p, ...) {
-  sel <- probe(.x, .p, ...)
-  .x[!is.na(sel) & sel]
+  where <- if_idx(.x, .p, ...)
+  .x[!is.na(where) & where]
 }
 
 #' @export
 #' @rdname keep
 discard <- function(.x, .p, ...) {
-  sel <- probe(.x, .p, ...)
-  .x[is.na(sel) | !sel]
+  where <- if_idx(.x, .p, ...)
+  .x[is.na(where) | !where]
 }
 
 #' @export
@@ -75,17 +75,13 @@ compact <- function(.x, .p = identity) {
 #' x %>% keep_at(~ nchar(.x) == 3)
 #' x %>% discard_at(~ nchar(.x) == 3)
 keep_at <- function(x, at) {
-  where <- at_selection(x, at)
+  where <- at_idx(x, at)
   x[where]
 }
 
 #' @export
 #' @rdname keep_at
 discard_at <- function(x, at) {
-  where <- at_selection(x, at)
-  if (length(where) == 0) {
-    x[]
-  } else {
-    x[-where]
-  }
+  where <- at_idx(x, at)
+  x[!where]
 }

--- a/R/lmap.R
+++ b/R/lmap.R
@@ -50,14 +50,14 @@ lmap <- function(.x, .f, ...) {
 #' @rdname lmap
 #' @export
 lmap_if <- function(.x, .p, .f, ..., .else = NULL) {
-  where <- if_idx(.x, .p)
+  where <- where_if(.x, .p)
   lmap_helper(.x, where, .f, ..., .else = .else)
 }
 
 #' @rdname lmap
 #' @export
 lmap_at <- function(.x, .at, .f, ...) {
-  where <- at_idx(.x, .at)
+  where <- where_at(.x, .at)
   lmap_helper(.x, where, .f, ...)
 }
 

--- a/R/lmap.R
+++ b/R/lmap.R
@@ -50,17 +50,15 @@ lmap <- function(.x, .f, ...) {
 #' @rdname lmap
 #' @export
 lmap_if <- function(.x, .p, .f, ..., .else = NULL) {
-  sel <- probe(.x, .p)
-  lmap_helper(.x, sel, .f, ..., .else = .else)
+  where <- if_idx(.x, .p)
+  lmap_helper(.x, where, .f, ..., .else = .else)
 }
 
 #' @rdname lmap
 #' @export
 lmap_at <- function(.x, .at, .f, ...) {
-  where <- at_selection(.x, .at)
-  sel <- inv_which(.x, where)
-
-  lmap_helper(.x, sel, .f, ...)
+  where <- at_idx(.x, .at)
+  lmap_helper(.x, where, .f, ...)
 }
 
 lmap_helper <- function(.x, .ind, .f, ..., .else = NULL, .error_call = caller_env()) {

--- a/R/map-if-at.R
+++ b/R/map-if-at.R
@@ -30,15 +30,15 @@
 #' map_if(iris, is.factor, as.character, .else = as.integer)
 #'
 map_if <- function(.x, .p, .f, ..., .else = NULL) {
-  sel <- probe(.x, .p)
+  where <- if_idx(.x, .p)
 
   out <- vector("list", length(.x))
-  out[sel]  <- map(.x[sel], .f, ...)
+  out[where]  <- map(.x[where], .f, ...)
 
   if (is_null(.else)) {
-    out[!sel] <- .x[!sel]
+    out[!where] <- .x[!where]
   } else {
-    out[!sel]  <- map(.x[!sel], .else, ...)
+    out[!where]  <- map(.x[!where], .else, ...)
   }
 
   set_names(out, names(.x))
@@ -60,12 +60,11 @@ map_if <- function(.x, .p, .f, ..., .else = NULL) {
 #
 #' @export
 map_at <- function(.x, .at, .f, ..., .progress = NULL) {
-  where <- at_selection(.x, .at)
-  sel <- inv_which(.x, where)
+  where <- at_idx(.x, .at)
 
   out <- vector("list", length(.x))
-  out[sel]  <- map(.x[sel], .f, ..., .progress = .progress)
-  out[!sel] <- .x[!sel]
+  out[where]  <- map(.x[where], .f, ..., .progress = .progress)
+  out[!where] <- .x[!where]
 
   set_names(out, names(.x))
 }

--- a/R/map-if-at.R
+++ b/R/map-if-at.R
@@ -30,7 +30,7 @@
 #' map_if(iris, is.factor, as.character, .else = as.integer)
 #'
 map_if <- function(.x, .p, .f, ..., .else = NULL) {
-  where <- if_idx(.x, .p)
+  where <- where_if(.x, .p)
 
   out <- vector("list", length(.x))
   out[where]  <- map(.x[where], .f, ...)
@@ -60,7 +60,7 @@ map_if <- function(.x, .p, .f, ..., .else = NULL) {
 #
 #' @export
 map_at <- function(.x, .at, .f, ..., .progress = NULL) {
-  where <- at_idx(.x, .at)
+  where <- where_at(.x, .at)
 
   out <- vector("list", length(.x))
   out[where]  <- map(.x[where], .f, ..., .progress = .progress)

--- a/R/map-mapper.R
+++ b/R/map-mapper.R
@@ -106,36 +106,3 @@ plucker <- function(i, default) {
     expr(pluck_raw(x, !!i, .default = !!default))
   )
 }
-
-as_predicate <- function(.fn,
-                         ...,
-                         .mapper,
-                         .allow_na = FALSE,
-                         .error_call = caller_env(),
-                         .error_arg = caller_arg(.fn)) {
-
-  force(.error_arg)
-  force(.error_call)
-
-  if (.mapper) {
-    .fn <- as_mapper(.fn, ...)
-  }
-
-  function(...) {
-    out <- .fn(...)
-
-    if (!is_bool(out)) {
-      if (is_na(out) && .allow_na) {
-        # Always return a logical NA
-        return(NA)
-      }
-      cli::cli_abort(
-        "{.fn { .error_arg }} must return a single `TRUE` or `FALSE`, not {.obj_type_friendly {out}}.",
-        arg = .error_arg,
-        call = .error_call
-      )
-    }
-
-    out
-  }
-}

--- a/R/modify.R
+++ b/R/modify.R
@@ -138,17 +138,17 @@ modify_if <- function(.x, .p, .f, ..., .else = NULL) {
 #' @rdname modify
 #' @export
 modify_if.default <- function(.x, .p, .f, ..., .else = NULL) {
-  sel <- probe(.x, .p)
+  where <- if_idx(.x, .p)
   index <- seq_along(.x)
 
   .f <- as_mapper(.f, ...)
-  for (i in index[sel]) {
+  for (i in index[where]) {
     list_slice2(.x, i) <- .f(.x[[i]], ...)
   }
 
   if (!is_null(.else)) {
     .else <- as_mapper(.else, ...)
-    for (i in index[!sel]) {
+    for (i in index[!where]) {
       list_slice2(.x, i) <- .else(.x[[i]], ...)
     }
   }
@@ -173,11 +173,11 @@ modify_if.logical <- function(.x, .p, .f, ..., .else = NULL) {
 }
 
 modify_if_base <- function(.fmap, .x, .p, .true, .false = NULL, ..., .error_call = caller_env()) {
-  sel <- probe(.x, .p, .error_call = .error_call)
-  .x[sel] <- .fmap(.x[sel], .true, ...)
+  where <- if_idx(.x, .p, .error_call = .error_call)
+  .x[where] <- .fmap(.x[where], .true, ...)
 
   if (!is.null(.false)) {
-    .x[!sel] <- .fmap(.x[!sel], .false, ...)
+    .x[!where] <- .fmap(.x[!where], .false, ...)
   }
 
   .x
@@ -194,36 +194,31 @@ modify_at <- function(.x, .at, .f, ...) {
 #' @rdname modify
 #' @export
 modify_at.default <- function(.x, .at, .f, ...) {
-  where <- at_selection(.x, .at)
-  sel <- inv_which(.x, where)
-  modify_if(.x, sel, .f, ...)
+  where <- at_idx(.x, .at)
+  modify_if(.x, where, .f, ...)
 }
 #' @export
 modify_at.integer <- function(.x, .at, .f, ...) {
-  where <- at_selection(.x, .at)
-  sel <- inv_which(.x, where)
-  .x[sel] <- map_int(.x[sel], .f, ...)
+  where <- at_idx(.x, .at)
+  .x[where] <- map_int(.x[where], .f, ...)
   .x
 }
 #' @export
 modify_at.double <- function(.x, .at, .f, ...) {
-  where <- at_selection(.x, .at)
-  sel <- inv_which(.x, where)
-  .x[sel] <- map_dbl(.x[sel], .f, ...)
+  where <- at_idx(.x, .at)
+  .x[where] <- map_dbl(.x[where], .f, ...)
   .x
 }
 #' @export
 modify_at.character <- function(.x, .at, .f, ...) {
-  where <- at_selection(.x, .at)
-  sel <- inv_which(.x, where)
-  .x[sel] <- map_chr(.x[sel], .f, ...)
+  where <- at_idx(.x, .at)
+  .x[where] <- map_chr(.x[where], .f, ...)
   .x
 }
 #' @export
 modify_at.logical <- function(.x, .at, .f, ...) {
-  where <- at_selection(.x, .at)
-  sel <- inv_which(.x, where)
-  .x[sel] <- map_lgl(.x[sel], .f, ...)
+  where <- at_idx(.x, .at)
+  .x[where] <- map_lgl(.x[where], .f, ...)
   .x
 }
 

--- a/R/modify.R
+++ b/R/modify.R
@@ -138,7 +138,7 @@ modify_if <- function(.x, .p, .f, ..., .else = NULL) {
 #' @rdname modify
 #' @export
 modify_if.default <- function(.x, .p, .f, ..., .else = NULL) {
-  where <- if_idx(.x, .p)
+  where <- where_if(.x, .p)
   index <- seq_along(.x)
 
   .f <- as_mapper(.f, ...)
@@ -173,7 +173,7 @@ modify_if.logical <- function(.x, .p, .f, ..., .else = NULL) {
 }
 
 modify_if_base <- function(.fmap, .x, .p, .true, .false = NULL, ..., .error_call = caller_env()) {
-  where <- if_idx(.x, .p, .error_call = .error_call)
+  where <- where_if(.x, .p, .error_call = .error_call)
   .x[where] <- .fmap(.x[where], .true, ...)
 
   if (!is.null(.false)) {
@@ -194,30 +194,30 @@ modify_at <- function(.x, .at, .f, ...) {
 #' @rdname modify
 #' @export
 modify_at.default <- function(.x, .at, .f, ...) {
-  where <- at_idx(.x, .at)
+  where <- where_at(.x, .at)
   modify_if(.x, where, .f, ...)
 }
 #' @export
 modify_at.integer <- function(.x, .at, .f, ...) {
-  where <- at_idx(.x, .at)
+  where <- where_at(.x, .at)
   .x[where] <- map_int(.x[where], .f, ...)
   .x
 }
 #' @export
 modify_at.double <- function(.x, .at, .f, ...) {
-  where <- at_idx(.x, .at)
+  where <- where_at(.x, .at)
   .x[where] <- map_dbl(.x[where], .f, ...)
   .x
 }
 #' @export
 modify_at.character <- function(.x, .at, .f, ...) {
-  where <- at_idx(.x, .at)
+  where <- where_at(.x, .at)
   .x[where] <- map_chr(.x[where], .f, ...)
   .x
 }
 #' @export
 modify_at.logical <- function(.x, .at, .f, ...) {
-  where <- at_idx(.x, .at)
+  where <- where_at(.x, .at)
   .x[where] <- map_lgl(.x[where], .f, ...)
   .x
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,4 +1,4 @@
-at_selection <- function(x, at, error_arg = caller_arg(at), error_call = caller_env()) {
+at_idx <- function(x, at, error_arg = caller_arg(at), error_call = caller_env()) {
   if (is_formula(at)) {
     at <- rlang::as_function(at, arg = error_arg, call = error_call)
   }
@@ -6,13 +6,19 @@ at_selection <- function(x, at, error_arg = caller_arg(at), error_call = caller_
     at <- at(names(x))
   }
 
+  if (is_quosures(at)) {
+    lifecycle::deprecate_warn("1.0.0", I("Using `vars()` in .at"))
+    check_installed("tidyselect", "for using tidyselect in `map_at()`.")
+
+    at <- tidyselect::vars_select(.vars = names(x), !!!at)
+  }
+
   if (is.numeric(at) || is.logical(at) || is.character(at)) {
     if (is.character(at)) {
       at <- intersect(at, names2(x))
     }
 
-    # at <- vec_as_subscript(at, arg = "at", call = error_call)
-    vec_as_location(
+    loc <- vec_as_location(
       at,
       length(x),
       names(x),
@@ -20,11 +26,7 @@ at_selection <- function(x, at, error_arg = caller_arg(at), error_call = caller_
       arg = "at",
       call = error_call
     )
-  } else if (is_quosures(at)) {
-    lifecycle::deprecate_warn("1.0.0", I("Using `vars()` in .at"))
-    check_installed("tidyselect", "for using tidyselect in `map_at()`.")
-
-    tidyselect::vars_select(.vars = names(x), !!!at)
+    seq_along(x) %in% loc
   } else {
     cli::cli_abort(
       "{.arg {error_arg}} must be a numeric vector, character vector, or function, not {.obj_type_friendly {at}}.",
@@ -34,35 +36,7 @@ at_selection <- function(x, at, error_arg = caller_arg(at), error_call = caller_
   }
 }
 
-inv_which <- function(x, sel, error_call = caller_env()) {
-  if (is.character(sel)) {
-    names <- names(x)
-    if (is.null(names)) {
-      cli::cli_abort(
-        "Character {.arg .at} must be used with a named {.arg x}.",
-        arg = ".at",
-        call = error_call
-      )
-    }
-    names %in% sel
-  } else if (is.numeric(sel)) {
-    if (any(sel < 0)) {
-      !seq_along(x) %in% abs(sel)
-    } else {
-      seq_along(x) %in% sel
-    }
-
-  } else {
-    cli::cli_abort(
-      "{.arg .at} must be a character or numeric vector, not {.obj_type_friendly {sel}}.",
-      arg = ".at",
-      call = error_call
-    )
-  }
-}
-
-# Internal version of map_lgl() that works with logical vectors
-probe <- function(.x, .p, ..., .error_call = caller_env()) {
+if_idx <- function(.x, .p, ..., .error_call = caller_env()) {
   if (is_logical(.p)) {
     stopifnot(length(.p) == length(.x))
     .p

--- a/R/utils.R
+++ b/R/utils.R
@@ -46,6 +46,39 @@ where_if <- function(.x, .p, ..., .error_call = caller_env()) {
   }
 }
 
+as_predicate <- function(.fn,
+                         ...,
+                         .mapper,
+                         .allow_na = FALSE,
+                         .error_call = caller_env(),
+                         .error_arg = caller_arg(.fn)) {
+
+  force(.error_arg)
+  force(.error_call)
+
+  if (.mapper) {
+    .fn <- as_mapper(.fn, ...)
+  }
+
+  function(...) {
+    out <- .fn(...)
+
+    if (!is_bool(out)) {
+      if (is_na(out) && .allow_na) {
+        # Always return a logical NA
+        return(NA)
+      }
+      cli::cli_abort(
+        "{.fn { .error_arg }} must return a single `TRUE` or `FALSE`, not {.obj_type_friendly {out}}.",
+        arg = .error_arg,
+        call = .error_call
+      )
+    }
+
+    out
+  }
+}
+
 paste_line <- function(...) {
   paste(chr(...), collapse = "\n")
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -3,14 +3,14 @@ where_at <- function(x, at, error_arg = caller_arg(at), error_call = caller_env(
     at <- rlang::as_function(at, arg = error_arg, call = error_call)
   }
   if (is.function(at)) {
-    at <- at(names(x))
+    at <- at(names2(x))
   }
 
   if (is_quosures(at)) {
     lifecycle::deprecate_warn("1.0.0", I("Using `vars()` in .at"))
     check_installed("tidyselect", "for using tidyselect in `map_at()`.")
 
-    at <- tidyselect::vars_select(.vars = names(x), !!!at)
+    at <- tidyselect::vars_select(.vars = names2(x), !!!at)
   }
 
   if (is.numeric(at) || is.logical(at) || is.character(at)) {
@@ -21,7 +21,7 @@ where_at <- function(x, at, error_arg = caller_arg(at), error_call = caller_env(
     loc <- vec_as_location(
       at,
       length(x),
-      names(x),
+      names2(x),
       missing = "error",
       arg = "at",
       call = error_call

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,4 +1,4 @@
-at_idx <- function(x, at, error_arg = caller_arg(at), error_call = caller_env()) {
+where_at <- function(x, at, error_arg = caller_arg(at), error_call = caller_env()) {
   if (is_formula(at)) {
     at <- rlang::as_function(at, arg = error_arg, call = error_call)
   }
@@ -36,7 +36,7 @@ at_idx <- function(x, at, error_arg = caller_arg(at), error_call = caller_env())
   }
 }
 
-if_idx <- function(.x, .p, ..., .error_call = caller_env()) {
+where_if <- function(.x, .p, ..., .error_call = caller_env()) {
   if (is_logical(.p)) {
     stopifnot(length(.p) == length(.x))
     .p

--- a/tests/testthat/_snaps/modify.md
+++ b/tests/testthat/_snaps/modify.md
@@ -1,11 +1,3 @@
-# modify_at requires a named object
-
-    Code
-      modify_at(list(), "x", toupper)
-    Condition
-      Error in `vec_as_location()`:
-      ! Can't use character names to index an unnamed vector.
-
 # modify_if() requires predicate functions
 
     Code

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -1,21 +1,21 @@
 # errors on invalid subsetting vectors
 
     Code
-      at_selection(x, c(FALSE, TRUE))
+      at_idx(x, c(FALSE, TRUE))
     Condition
       Error:
       ! Must subset elements with a valid subscript vector.
       i Logical subscripts must match the size of the indexed input.
       x Input has size 3 but subscript `at` has size 2.
     Code
-      at_selection(x, NA_real_)
+      at_idx(x, NA_real_)
     Condition
       Error:
       ! Must subset elements with a valid subscript vector.
       x Subscript can't contain missing values.
       x It has a missing value at location 1.
     Code
-      at_selection(x, 4)
+      at_idx(x, 4)
     Condition
       Error:
       ! Can't subset elements past the end.
@@ -25,7 +25,7 @@
 # validates its inputs
 
     Code
-      at_selection(x, list())
+      at_idx(x, list())
     Condition
       Error:
       ! `list()` must be a numeric vector, character vector, or function, not an empty list.
@@ -33,7 +33,7 @@
 # tidyselect `at` is deprecated
 
     Code
-      . <- at_selection(data.frame(x = 1), vars("x"))
+      . <- at_idx(data.frame(x = 1), vars("x"))
     Condition
       Warning:
       Using `vars()` in .at was deprecated in purrr 1.0.0.

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -1,21 +1,21 @@
 # errors on invalid subsetting vectors
 
     Code
-      at_idx(x, c(FALSE, TRUE))
+      where_at(x, c(FALSE, TRUE))
     Condition
       Error:
       ! Must subset elements with a valid subscript vector.
       i Logical subscripts must match the size of the indexed input.
       x Input has size 3 but subscript `at` has size 2.
     Code
-      at_idx(x, NA_real_)
+      where_at(x, NA_real_)
     Condition
       Error:
       ! Must subset elements with a valid subscript vector.
       x Subscript can't contain missing values.
       x It has a missing value at location 1.
     Code
-      at_idx(x, 4)
+      where_at(x, 4)
     Condition
       Error:
       ! Can't subset elements past the end.
@@ -25,7 +25,7 @@
 # validates its inputs
 
     Code
-      at_idx(x, list())
+      where_at(x, list())
     Condition
       Error:
       ! `list()` must be a numeric vector, character vector, or function, not an empty list.
@@ -33,7 +33,7 @@
 # tidyselect `at` is deprecated
 
     Code
-      . <- at_idx(data.frame(x = 1), vars("x"))
+      . <- where_at(data.frame(x = 1), vars("x"))
     Condition
       Warning:
       Using `vars()` in .at was deprecated in purrr 1.0.0.

--- a/tests/testthat/test-modify.R
+++ b/tests/testthat/test-modify.R
@@ -19,10 +19,6 @@ test_that("modify_if/modify_at return same type as input", {
   expect_equal(df2b, exp)
 })
 
-test_that("modify_at requires a named object", {
-  expect_snapshot(modify_at(list(), "x", toupper), error = TRUE)
-})
-
 test_that("negative .at omits locations", {
   x <- list(1, 2, 3)
   out <- modify_at(x, -1, ~ .x * 2)

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,35 +1,35 @@
-# at_idx ------------------------------------------------------------
+# where_at ------------------------------------------------------------
 
 test_that("allows valid logical, numeric, and character vectors", {
   x <- list(a = 1, b = 1, c = 1)
-  expect_equal(at_idx(x, TRUE), c(TRUE, TRUE, TRUE))
-  expect_equal(at_idx(x, 1), c(TRUE, FALSE, FALSE))
-  expect_equal(at_idx(x, -2), c(TRUE, FALSE, TRUE))
-  expect_equal(at_idx(x, "b"), c(FALSE, TRUE, FALSE))
+  expect_equal(where_at(x, TRUE), c(TRUE, TRUE, TRUE))
+  expect_equal(where_at(x, 1), c(TRUE, FALSE, FALSE))
+  expect_equal(where_at(x, -2), c(TRUE, FALSE, TRUE))
+  expect_equal(where_at(x, "b"), c(FALSE, TRUE, FALSE))
 })
 
 test_that("errors on invalid subsetting vectors", {
   x <- list(a = 1, b = 1, c = 1)
   expect_snapshot(error = TRUE, {
-    at_idx(x, c(FALSE, TRUE))
-    at_idx(x, NA_real_)
-    at_idx(x, 4)
+    where_at(x, c(FALSE, TRUE))
+    where_at(x, NA_real_)
+    where_at(x, 4)
   })
 })
 
 test_that("function at is passed names", {
   x <- list(a = 1, B = 1, c = 1)
-  expect_equal(at_idx(x, ~ .x %in% LETTERS), c(FALSE, TRUE, FALSE))
-  expect_equal(at_idx(x, ~ intersect(.x, LETTERS)), c(FALSE, TRUE, FALSE))
+  expect_equal(where_at(x, ~ .x %in% LETTERS), c(FALSE, TRUE, FALSE))
+  expect_equal(where_at(x, ~ intersect(.x, LETTERS)), c(FALSE, TRUE, FALSE))
 })
 
 test_that("validates its inputs", {
   x <- list(a = 1, b = 1, c = 1)
-  expect_snapshot(at_idx(x, list()), error = TRUE)
+  expect_snapshot(where_at(x, list()), error = TRUE)
 })
 
 test_that("tidyselect `at` is deprecated", {
   expect_snapshot({
-    . <- at_idx(data.frame(x = 1), vars("x"))
+    . <- where_at(data.frame(x = 1), vars("x"))
   })
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -23,6 +23,12 @@ test_that("function at is passed names", {
   expect_equal(where_at(x, ~ intersect(.x, LETTERS)), c(FALSE, TRUE, FALSE))
 })
 
+test_that("where_at works with unnamed input", {
+  x <- list(1, 1, 1)
+  expect_equal(where_at(x, letters), rep(FALSE, 3))
+  expect_equal(where_at(x, ~ intersect(.x, LETTERS)), rep(FALSE, 3))
+})
+
 test_that("validates its inputs", {
   x <- list(a = 1, b = 1, c = 1)
   expect_snapshot(where_at(x, list()), error = TRUE)

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,35 +1,35 @@
-# at_selection ------------------------------------------------------------
+# at_idx ------------------------------------------------------------
 
 test_that("allows valid logical, numeric, and character vectors", {
   x <- list(a = 1, b = 1, c = 1)
-  expect_equal(at_selection(x, TRUE), c(1, 2, 3))
-  expect_equal(at_selection(x, 1), 1)
-  expect_equal(at_selection(x, -2), c(1, 3))
-  expect_equal(at_selection(x, "b"), 2)
+  expect_equal(at_idx(x, TRUE), c(TRUE, TRUE, TRUE))
+  expect_equal(at_idx(x, 1), c(TRUE, FALSE, FALSE))
+  expect_equal(at_idx(x, -2), c(TRUE, FALSE, TRUE))
+  expect_equal(at_idx(x, "b"), c(FALSE, TRUE, FALSE))
 })
 
 test_that("errors on invalid subsetting vectors", {
   x <- list(a = 1, b = 1, c = 1)
   expect_snapshot(error = TRUE, {
-    at_selection(x, c(FALSE, TRUE))
-    at_selection(x, NA_real_)
-    at_selection(x, 4)
+    at_idx(x, c(FALSE, TRUE))
+    at_idx(x, NA_real_)
+    at_idx(x, 4)
   })
 })
 
 test_that("function at is passed names", {
   x <- list(a = 1, B = 1, c = 1)
-  expect_equal(at_selection(x, ~ .x %in% LETTERS), 2)
-  expect_equal(at_selection(x, ~ intersect(.x, LETTERS)), 2)
+  expect_equal(at_idx(x, ~ .x %in% LETTERS), c(FALSE, TRUE, FALSE))
+  expect_equal(at_idx(x, ~ intersect(.x, LETTERS)), c(FALSE, TRUE, FALSE))
 })
 
 test_that("validates its inputs", {
   x <- list(a = 1, b = 1, c = 1)
-  expect_snapshot(at_selection(x, list()), error = TRUE)
+  expect_snapshot(at_idx(x, list()), error = TRUE)
 })
 
 test_that("tidyselect `at` is deprecated", {
   expect_snapshot({
-    . <- at_selection(data.frame(x = 1), vars("x"))
+    . <- at_idx(data.frame(x = 1), vars("x"))
   })
 })


### PR DESCRIPTION
* `probe()` -> `where_if()`
* `at_selection()` -> `where_at()`

`where_at()` now generates a logical vector directly, rather than going through `inv_which()`.

---

@DavisVaughan the most useful feedback would be on the names.