### PR TITLE
Default otherwise to NULL

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -184,6 +184,8 @@
 * `as_mapper()` is now around twice as fast when used with character,
   integer, or list (#820).
 
+* `possibly()` now defaults `otherwise` to NULL.
+
 * `modify_if(.else)` is now actually evaluated for atomic vectors (@mgirlich, 
   #701).
    

--- a/R/adverb-possibly.R
+++ b/R/adverb-possibly.R
@@ -12,6 +12,11 @@
 #' # To replace errors with a default value, use possibly().
 #' list("a", 10, 100) |>
 #'   map_dbl(possibly(log, NA_real_))
+#'
+#' # The default, NULL, will be discarded with `list_c()`
+#' list("a", 10, 100) |>
+#'   map(possibly(log)) |>
+#'   list_c()
 possibly <- function(.f, otherwise = NULL, quiet = TRUE) {
   .f <- as_mapper(.f)
   force(otherwise)

--- a/R/adverb-possibly.R
+++ b/R/adverb-possibly.R
@@ -12,7 +12,7 @@
 #' # To replace errors with a default value, use possibly().
 #' list("a", 10, 100) |>
 #'   map_dbl(possibly(log, NA_real_))
-possibly <- function(.f, otherwise, quiet = TRUE) {
+possibly <- function(.f, otherwise = NULL, quiet = TRUE) {
   .f <- as_mapper(.f)
   force(otherwise)
 

--- a/man/possibly.Rd
+++ b/man/possibly.Rd
@@ -38,6 +38,11 @@ in a package, be sure to read \link{faq-adverbs-export}.
 # To replace errors with a default value, use possibly().
 list("a", 10, 100) |>
   map_dbl(possibly(log, NA_real_))
+
+# The default, NULL, will be discarded with `list_c()`
+list("a", 10, 100) |>
+  map(possibly(log)) |>
+  list_c()
 }
 \seealso{
 Other adverbs: 

--- a/man/possibly.Rd
+++ b/man/possibly.Rd
@@ -4,7 +4,7 @@
 \alias{possibly}
 \title{Wrap a function to return a value instead of an error}
 \usage{
-possibly(.f, otherwise, quiet = TRUE)
+possibly(.f, otherwise = NULL, quiet = TRUE)
 }
 \arguments{
 \item{.f}{A function to modify, specified in one of the following ways:


### PR DESCRIPTION
I feel like this is probably the most common/useful value and increases the consistency with `pluck()`, and makes it work nicely with #952.