### PR TITLE
Use soft deprecation for 1.0.0

### DIFF
--- a/R/deprec-along.R
+++ b/R/deprec-along.R
@@ -21,7 +21,7 @@
 #' @rdname along
 #' @export
 list_along <- function(x) {
-  lifecycle::deprecate_warn("1.0.0", "list_along()", I("rep_along(x, list())"))
+  lifecycle::deprecate_soft("1.0.0", "list_along()", I("rep_along(x, list())"))
 
   vector("list", length(x))
 }

--- a/R/deprec-invoke.R
+++ b/R/deprec-invoke.R
@@ -79,7 +79,7 @@
 #'
 #' @export
 invoke <- function(.f, .x = NULL, ..., .env = NULL) {
-  lifecycle::deprecate_warn("1.0.0", "invoke()", "exec()")
+  lifecycle::deprecate_soft("1.0.0", "invoke()", "exec()")
 
   .env <- .env %||% parent.frame()
   args <- c(as.list(.x), list(...))
@@ -97,7 +97,7 @@ as_invoke_function <- function(f) {
 #' @rdname invoke
 #' @export
 invoke_map <- function(.f, .x = list(NULL), ..., .env = NULL) {
-  lifecycle::deprecate_warn("1.0.0", "invoke_map()", I("map() + exec()"))
+  lifecycle::deprecate_soft("1.0.0", "invoke_map()", I("map() + exec()"))
 
   .env <- .env %||% parent.frame()
   .f <- as_invoke_function(.f)
@@ -106,7 +106,7 @@ invoke_map <- function(.f, .x = list(NULL), ..., .env = NULL) {
 #' @rdname invoke
 #' @export
 invoke_map_lgl <- function(.f, .x = list(NULL), ..., .env = NULL) {
-  lifecycle::deprecate_warn("1.0.0", "invoke_lgl()", I("map_lgl() + exec()"))
+  lifecycle::deprecate_soft("1.0.0", "invoke_lgl()", I("map_lgl() + exec()"))
 
   .env <- .env %||% parent.frame()
   .f <- as_invoke_function(.f)
@@ -115,7 +115,7 @@ invoke_map_lgl <- function(.f, .x = list(NULL), ..., .env = NULL) {
 #' @rdname invoke
 #' @export
 invoke_map_int <- function(.f, .x = list(NULL), ..., .env = NULL) {
-  lifecycle::deprecate_warn("1.0.0", "invoke_int()", I("map_int() + exec()"))
+  lifecycle::deprecate_soft("1.0.0", "invoke_int()", I("map_int() + exec()"))
 
   .env <- .env %||% parent.frame()
   .f <- as_invoke_function(.f)
@@ -124,7 +124,7 @@ invoke_map_int <- function(.f, .x = list(NULL), ..., .env = NULL) {
 #' @rdname invoke
 #' @export
 invoke_map_dbl <- function(.f, .x = list(NULL), ..., .env = NULL) {
-  lifecycle::deprecate_warn("1.0.0", "invoke_dbl()", I("map_dbl() + exec()"))
+  lifecycle::deprecate_soft("1.0.0", "invoke_dbl()", I("map_dbl() + exec()"))
 
   .env <- .env %||% parent.frame()
   .f <- as_invoke_function(.f)
@@ -133,7 +133,7 @@ invoke_map_dbl <- function(.f, .x = list(NULL), ..., .env = NULL) {
 #' @rdname invoke
 #' @export
 invoke_map_chr <- function(.f, .x = list(NULL), ..., .env = NULL) {
-  lifecycle::deprecate_warn("1.0.0", "invoke_chr()", I("map_chr() + exec()"))
+  lifecycle::deprecate_soft("1.0.0", "invoke_chr()", I("map_chr() + exec()"))
 
   .env <- .env %||% parent.frame()
   .f <- as_invoke_function(.f)
@@ -142,7 +142,7 @@ invoke_map_chr <- function(.f, .x = list(NULL), ..., .env = NULL) {
 #' @rdname invoke
 #' @export
 invoke_map_raw <- function(.f, .x = list(NULL), ..., .env = NULL) {
-  lifecycle::deprecate_warn("1.0.0", "invoke_raw()", I("map_raw() + exec()"))
+  lifecycle::deprecate_soft("1.0.0", "invoke_raw()", I("map_raw() + exec()"))
 
   .env <- .env %||% parent.frame()
   .f <- as_invoke_function(.f)
@@ -153,7 +153,7 @@ invoke_map_raw <- function(.f, .x = list(NULL), ..., .env = NULL) {
 #' @rdname invoke
 #' @export
 invoke_map_dfr <- function(.f, .x = list(NULL), ..., .env = NULL) {
-  lifecycle::deprecate_warn("1.0.0", "invoke_df()", I("map() + exec() + list_rbind()"))
+  lifecycle::deprecate_soft("1.0.0", "invoke_df()", I("map() + exec() + list_rbind()"))
 
   .env <- .env %||% parent.frame()
   .f <- as_invoke_function(.f)
@@ -162,7 +162,7 @@ invoke_map_dfr <- function(.f, .x = list(NULL), ..., .env = NULL) {
 #' @rdname invoke
 #' @export
 invoke_map_dfc <- function(.f, .x = list(NULL), ..., .env = NULL) {
-  lifecycle::deprecate_warn("1.0.0", "invoke_dfc()", I("map() + exec() + list_cbind()"))
+  lifecycle::deprecate_soft("1.0.0", "invoke_dfc()", I("map() + exec() + list_cbind()"))
 
   .env <- .env %||% parent.frame()
   .f <- as_invoke_function(.f)
@@ -172,7 +172,7 @@ invoke_map_dfc <- function(.f, .x = list(NULL), ..., .env = NULL) {
 #' @export
 #' @usage NULL
 invoke_map_df <- function(.f, .x = list(NULL), ..., .env = NULL) {
-  lifecycle::deprecate_warn("1.0.0", "invoke_df()", I("map() + exec() + list_rbind()"))
+  lifecycle::deprecate_soft("1.0.0", "invoke_df()", I("map() + exec() + list_rbind()"))
 
   .env <- .env %||% parent.frame()
   .f <- as_invoke_function(.f)

--- a/R/deprec-prepend.R
+++ b/R/deprec-prepend.R
@@ -26,7 +26,7 @@
 #' x |> prepend(list("a", "b"), before = 3)
 #' prepend(list(), x)
 prepend <- function(x, values, before = NULL) {
-  lifecycle::deprecate_warn("1.0.0", "prepend()", I("append(after = 0)"))
+  lifecycle::deprecate_soft("1.0.0", "prepend()", I("append(after = 0)"))
 
   n <- length(x)
   stopifnot(is.null(before) || (before > 0 && before <= n))

--- a/R/deprec-rerun.R
+++ b/R/deprec-rerun.R
@@ -64,7 +64,7 @@ deprec_rerun <- function(.n, ...) {
     new <- substitute(map(1:n, ~ list(...)))
   }
 
-  lifecycle::deprecate_warn("1.0.0", "rerun()", "map()", details = paste_line(
+  lifecycle::deprecate_soft("1.0.0", "rerun()", "map()", details = paste_line(
     "  # Previously",
     paste0("  ", expr_deparse(old)),
     "",

--- a/R/deprec-simplify.R
+++ b/R/deprec-simplify.R
@@ -29,7 +29,7 @@
 #' # now:
 #' list(1:2, 3:4, 5:6) |> list_c(ptype = integer())
 as_vector <- function(.x, .type = NULL) {
-  lifecycle::deprecate_warn("1.0.0", "as_vector()", "list_simplify()")
+  lifecycle::deprecate_soft("1.0.0", "as_vector()", "list_simplify()")
   as_vector_(.x, .type)
 }
 as_vector_ <- function(.x, .type = NULL) {
@@ -46,7 +46,7 @@ as_vector_ <- function(.x, .type = NULL) {
 #' @export
 #' @rdname as_vector
 simplify <- function(.x, .type = NULL) {
-  lifecycle::deprecate_warn("1.0.0", "as_vector()", "list_simplify()")
+  lifecycle::deprecate_soft("1.0.0", "as_vector()", "list_simplify()")
   if (can_simplify(.x, .type)) {
     unlist(.x)
   } else {
@@ -57,7 +57,7 @@ simplify <- function(.x, .type = NULL) {
 #' @export
 #' @rdname as_vector
 simplify_all <- function(.x, .type = NULL) {
-  lifecycle::deprecate_warn("1.0.0", "as_vector()", I("map() + list_simplify()"))
+  lifecycle::deprecate_soft("1.0.0", "as_vector()", I("map() + list_simplify()"))
 
   # Inline simplify to avoid double deprecation
   simplify <- function(.x) {

--- a/R/deprec-splice.R
+++ b/R/deprec-splice.R
@@ -22,7 +22,7 @@
 #' c(inputs, arg3 = c("c1", "c2")) |> str()
 #' @export
 splice <- function(...) {
-  lifecycle::deprecate_warn("1.0.0", "splice()", "list_flatten()")
+  lifecycle::deprecate_soft("1.0.0", "splice()", "list_flatten()")
 
   splice_if(list(...), is_bare_list)
 }

--- a/R/deprec-transpose.R
+++ b/R/deprec-transpose.R
@@ -62,6 +62,6 @@
 #' # and can supply default value
 #' ll |> list_transpose(template = nms, default = NA)
 transpose <- function(.l, .names = NULL) {
-  lifecycle::deprecate_warn("1.0.0", "transpose()", "list_transpose()")
+  lifecycle::deprecate_soft("1.0.0", "transpose()", "list_transpose()")
   .Call(transpose_impl, .l, .names)
 }

--- a/R/deprec-utils.R
+++ b/R/deprec-utils.R
@@ -34,7 +34,7 @@
 #' rbernoulli(10)
 #' rbernoulli(100, 0.1)
 rbernoulli <- function(n, p = 0.5) {
-  lifecycle::deprecate_warn("1.0.0", "rbernoulli()")
+  lifecycle::deprecate_soft("1.0.0", "rbernoulli()")
   stats::runif(n) > (1 - p)
 }
 
@@ -54,7 +54,7 @@ rbernoulli <- function(n, p = 0.5) {
 #' table(rdunif(1e3, 10))
 #' table(rdunif(1e3, 10, -5))
 rdunif <- function(n, b, a = 1) {
-  lifecycle::deprecate_warn("1.0.0", "rdunif()")
+  lifecycle::deprecate_soft("1.0.0", "rdunif()")
 
   stopifnot(is.numeric(a), length(a) == 1)
   stopifnot(is.numeric(b), length(b) == 1)

--- a/R/deprec-when.R
+++ b/R/deprec-when.R
@@ -63,7 +63,7 @@
 #'        ~ stop("Expected fewer than 10 rows."))
 #' @export
 when <- function(., ...) {
-  lifecycle::deprecate_warn("1.0.0", "when()", "dplyr::case_when()")
+  lifecycle::deprecate_soft("1.0.0", "when()", "dplyr::case_when()")
 
   dots   <- list(...)
   names  <- names(dots)

--- a/R/list-modify.R
+++ b/R/list-modify.R
@@ -107,7 +107,7 @@ list_recurse <- function(x, y, base_f, recurse = TRUE, error_call = caller_env()
 #' @export
 #' @keywords internal
 update_list <- function(.x, ...) {
-  lifecycle::deprecate_warn("1.0.0", "update_list()")
+  lifecycle::deprecate_soft("1.0.0", "update_list()")
 
   dots <- dots_list(...)
 

--- a/R/map-raw.R
+++ b/R/map-raw.R
@@ -10,7 +10,7 @@
 #' @keywords internal
 #' @export
 map_raw <- function(.x, .f, ...) {
-  lifecycle::deprecate_warn("1.0.0", "map_raw()", "map_vec()")
+  lifecycle::deprecate_soft("1.0.0", "map_raw()", "map_vec()")
 
   .f <- as_mapper(.f, ...)
   .Call(map_impl, environment(), ".x", ".f", "raw", FALSE)
@@ -19,7 +19,7 @@ map_raw <- function(.x, .f, ...) {
 #' @export
 #' @rdname map_raw
 map2_raw <- function(.x, .y, .f, ...) {
-  lifecycle::deprecate_warn("1.0.0", "map2_raw()", "map2_vec()")
+  lifecycle::deprecate_soft("1.0.0", "map2_raw()", "map2_vec()")
   map2_raw_(.x, .y, .f, ...)
 }
 map2_raw_ <- function(.x, .y, .f, ...) {
@@ -30,7 +30,7 @@ map2_raw_ <- function(.x, .y, .f, ...) {
 #' @rdname map_raw
 #' @export
 imap_raw <- function(.x, .f, ...) {
-  lifecycle::deprecate_warn("1.0.0", "imap_raw()", "imap_vec()")
+  lifecycle::deprecate_soft("1.0.0", "imap_raw()", "imap_vec()")
 
   .f <- as_mapper(.f, ...)
   map2_raw(.x, vec_index(.x), .f, ...)
@@ -39,7 +39,7 @@ imap_raw <- function(.x, .f, ...) {
 #' @export
 #' @rdname map_raw
 pmap_raw <- function(.l, .f, ...) {
-  lifecycle::deprecate_warn("1.0.0", "pmap_raw()", "pmap_vec()")
+  lifecycle::deprecate_soft("1.0.0", "pmap_raw()", "pmap_vec()")
 
   .f <- as_mapper(.f, ...)
   if (is.data.frame(.l)) {
@@ -52,6 +52,6 @@ pmap_raw <- function(.l, .f, ...) {
 #' @export
 #' @rdname map_raw
 flatten_raw <- function(.x) {
-  lifecycle::deprecate_warn("1.0.0", "flatten_raw()")
+  lifecycle::deprecate_soft("1.0.0", "flatten_raw()")
   .Call(vflatten_impl, .x, "raw")
 }

--- a/R/pluck-depth.R
+++ b/R/pluck-depth.R
@@ -29,6 +29,6 @@ pluck_depth <- function(x) {
 #' @rdname pluck_depth
 #' @usage NULL
 vec_depth <- function(x) {
-  lifecycle::deprecate_warn("1.0.0", "vec_depth()", "pluck_depth()")
+  lifecycle::deprecate_soft("1.0.0", "vec_depth()", "pluck_depth()")
   pluck_depth(x)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -7,7 +7,7 @@ where_at <- function(x, at, error_arg = caller_arg(at), error_call = caller_env(
   }
 
   if (is_quosures(at)) {
-    lifecycle::deprecate_warn("1.0.0", I("Using `vars()` in .at"))
+    lifecycle::deprecate_soft("1.0.0", I("Using `vars()` in .at"))
     check_installed("tidyselect", "for using tidyselect in `map_at()`.")
 
     at <- tidyselect::vars_select(.vars = names2(x), !!!at)


### PR DESCRIPTION
The only exception is for `deprecate_to_char()` where it's difficult to pass the correct environment and is more likely to be incorrect anyway.

Fixes #954