### PR TITLE
Pass user env to lifecycle

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Depends:
     R (>= 3.2.3)
 Imports:
     cli (>= 3.4.0),
-    lifecycle (>= 1.0.2),
+    lifecycle (>= 1.0.2.9000),
     magrittr (>= 1.5.0),
     rlang (>= 0.4.10),
     vctrs (>= 0.4.1.9001)
@@ -37,4 +37,5 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.1
 Config/testthat/edition: 3
 Remotes:  
+    r-lib/lifecycle,
     r-lib/vctrs

--- a/R/coerce.R
+++ b/R/coerce.R
@@ -10,11 +10,12 @@ coerce_dbl <- function(x) coerce(x, "double")
 coerce_chr <- function(x) coerce(x, "character")
 
 
-deprecate_to_char <- function(type) {
+deprecate_to_char <- function(type, call = caller_env()) {
   lifecycle::deprecate_warn(
     "1.0.0",
     I(paste0("Automatic coercion from ", type, " to character")),
     I("an explicit call to as.character() within map_chr()"),
-    always = TRUE
+    always = TRUE,
+    user_env = call
   )
 }

--- a/src/coerce.c
+++ b/src/coerce.c
@@ -62,19 +62,14 @@ double integer_to_real(int x) {
 }
 
 void deprecate_to_char(const char* type) {
-  SEXP fn = PROTECT(Rf_lang3(
-    Rf_install(":::"),
-    Rf_install("purrr"),
-    Rf_install("deprecate_to_char")
-  ));
-
   SEXP call = PROTECT(Rf_lang2(
-    PROTECT(fn),
+    Rf_install("deprecate_to_char"),
     PROTECT(Rf_mkString("type"))
   ));
+  SEXP env = PROTECT(caller_env());
 
-  Rf_eval(call, R_BaseEnv);
-  UNPROTECT(4);
+  Rf_eval(call, env);
+  UNPROTECT(3);
 }
 
 SEXP logical_to_char(int x, SEXP from, SEXP to, int i) {


### PR DESCRIPTION
To differentiate between direct and indirect calls, needed for compatibility with dev lifecycle which implements different verbosity levels for these cases.