### PR TITLE
Cleanup C level `map()` code

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,8 +27,7 @@ Suggests:
     tibble,
     tidyselect
 LinkingTo:
-    cli,
-    vctrs
+    cli
 VignetteBuilder: 
     knitr
 Config/Needs/website: tidyverse/tidytemplate

--- a/R/map.R
+++ b/R/map.R
@@ -164,7 +164,7 @@ map_ <- function(.type, .x, .f, ..., .progress = FALSE, ..error_call = caller_en
   with_indexed_errors(
     i = i,
     error_call = ..error_call,
-    .Call(map_impl, environment(), .type, .progress, n, names, i, ..error_call)
+    .Call(map_impl, environment(), .type, .progress, n, names, i)
   )
 }
 

--- a/R/map.R
+++ b/R/map.R
@@ -153,16 +153,18 @@ map_chr <- function(.x, .f, ..., .progress = FALSE) {
 map_ <- function(.type, .x, .f, ..., .progress = FALSE, ..error_call = caller_env()) {
   .x <- vctrs_vec_compat(.x)
   vec_assert(.x, arg = ".x", call = ..error_call)
+
   n <- vec_size(.x)
 
-  .f <- as_mapper(.f, ...)
   names <- vec_names(.x)
+
+  .f <- as_mapper(.f, ...)
 
   i <- 0L
   with_indexed_errors(
     i = i,
     error_call = ..error_call,
-    .Call(map_impl, environment(), .type, .progress, ..error_call)
+    .Call(map_impl, environment(), .type, .progress, n, names, i, ..error_call)
   )
 }
 

--- a/R/map2.R
+++ b/R/map2.R
@@ -57,19 +57,21 @@ map2_chr <- function(.x, .y, .f, ..., .progress = FALSE) {
 map2_ <- function(.type, .x, .y, .f, ..., .progress = FALSE, ..error_call = caller_env()) {
   .x <- vctrs_vec_compat(.x)
   .y <- vctrs_vec_compat(.y)
+
   n <- vec_size_common(.x = .x, .y = .y, .call = ..error_call)
   args <- vec_recycle_common(.x = .x, .y = .y, .size = n, .call = ..error_call)
   .x <- args$.x
   .y <- args$.y
 
-  .f <- as_mapper(.f, ...)
   names <- vec_names(.x)
+
+  .f <- as_mapper(.f, ...)
 
   i <- 0L
   with_indexed_errors(
     i = i,
     error_call = ..error_call,
-    .Call(map2_impl, environment(), .type, .progress, ..error_call)
+    .Call(map2_impl, environment(), .type, .progress, n, names, i, ..error_call)
   )
 }
 

--- a/R/map2.R
+++ b/R/map2.R
@@ -71,7 +71,7 @@ map2_ <- function(.type, .x, .y, .f, ..., .progress = FALSE, ..error_call = call
   with_indexed_errors(
     i = i,
     error_call = ..error_call,
-    .Call(map2_impl, environment(), .type, .progress, n, names, i, ..error_call)
+    .Call(map2_impl, environment(), .type, .progress, n, names, i)
   )
 }
 

--- a/R/package-purrr.R
+++ b/R/package-purrr.R
@@ -5,8 +5,3 @@
 #' @importFrom lifecycle deprecated
 #' @useDynLib purrr, .registration = TRUE
 "_PACKAGE"
-
-
-.onLoad <- function(lib, pkg) {
-  .Call(purrr_init_library, ns_env(pkg))
-}

--- a/R/pmap.R
+++ b/R/pmap.R
@@ -121,7 +121,7 @@ pmap_ <- function(.type, .l, .f, ..., .progress = FALSE, ..error_call = caller_e
   with_indexed_errors(
     i = i,
     error_call = ..error_call,
-    .Call(pmap_impl, environment(), .type, .progress, n, names, i, call_names, call_n, ..error_call)
+    .Call(pmap_impl, environment(), .type, .progress, n, names, i, call_names, call_n)
   )
 }
 

--- a/R/pmap.R
+++ b/R/pmap.R
@@ -102,21 +102,26 @@ pmap_chr <- function(.l, .f, ..., .progress = FALSE) {
 pmap_ <- function(.type, .l, .f, ..., .progress = FALSE, ..error_call = caller_env()) {
   .l <- vctrs_list_compat(.l, error_call = ..error_call)
   .l <- map(.l, vctrs_vec_compat)
+
   n <- vec_size_common(!!!.l, .arg = ".l", .call = ..error_call)
   .l <- vec_recycle_common(!!!.l, .size = n, .arg = ".l", .call = ..error_call)
 
-  .f <- as_mapper(.f, ...)
   if (length(.l) > 0L) {
     names <- vec_names(.l[[1L]])
   } else {
     names <- NULL
   }
 
+  .f <- as_mapper(.f, ...)
+
+  call_names <- names(.l)
+  call_n <- length(.l)
+
   i <- 0L
   with_indexed_errors(
     i = i,
     error_call = ..error_call,
-    .Call(pmap_impl, environment(), .type, .progress, ..error_call)
+    .Call(pmap_impl, environment(), .type, .progress, n, names, i, call_names, call_n, ..error_call)
   )
 }
 

--- a/src/init.c
+++ b/src/init.c
@@ -11,9 +11,9 @@
 extern SEXP coerce_impl(SEXP, SEXP);
 extern SEXP pluck_impl(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP flatten_impl(SEXP);
-extern SEXP map_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
-extern SEXP map2_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
-extern SEXP pmap_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP map_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP map2_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP pmap_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP transpose_impl(SEXP, SEXP);
 extern SEXP vflatten_impl(SEXP, SEXP);
 
@@ -21,9 +21,9 @@ static const R_CallMethodDef CallEntries[] = {
   {"coerce_impl",           (DL_FUNC) &coerce_impl,    2},
   {"pluck_impl",            (DL_FUNC) &pluck_impl,     5},
   {"flatten_impl",          (DL_FUNC) &flatten_impl,   1},
-  {"map_impl",              (DL_FUNC) &map_impl,       7},
-  {"map2_impl",             (DL_FUNC) &map2_impl,      7},
-  {"pmap_impl",             (DL_FUNC) &pmap_impl,      9},
+  {"map_impl",              (DL_FUNC) &map_impl,       6},
+  {"map2_impl",             (DL_FUNC) &map2_impl,      6},
+  {"pmap_impl",             (DL_FUNC) &pmap_impl,      8},
   {"transpose_impl",        (DL_FUNC) &transpose_impl, 2},
   {"vflatten_impl",         (DL_FUNC) &vflatten_impl,  2},
   {"purrr_eval",            (DL_FUNC) &Rf_eval,        2},

--- a/src/init.c
+++ b/src/init.c
@@ -7,9 +7,6 @@
 #include <R_ext/Visibility.h>
 #define export attribute_visible extern
 
-SEXP purrr_init_library(SEXP);
-
-
 /* .Call calls */
 extern SEXP coerce_impl(SEXP, SEXP);
 extern SEXP pluck_impl(SEXP, SEXP, SEXP, SEXP, SEXP);
@@ -21,7 +18,6 @@ extern SEXP transpose_impl(SEXP, SEXP);
 extern SEXP vflatten_impl(SEXP, SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
-  {"purrr_init_library",    (DL_FUNC) &purrr_init_library, 1},
   {"coerce_impl",           (DL_FUNC) &coerce_impl,    2},
   {"pluck_impl",            (DL_FUNC) &pluck_impl,   5},
   {"flatten_impl",          (DL_FUNC) &flatten_impl,   1},
@@ -38,11 +34,4 @@ export void R_init_purrr(DllInfo *dll)
 {
     R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
     R_useDynamicSymbols(dll, FALSE);
-}
-
-void vctrs_init_api(); // From <vctrs.c>
-
-SEXP purrr_init_library(SEXP ns) {
-  vctrs_init_api();
-  return R_NilValue;
 }

--- a/src/init.c
+++ b/src/init.c
@@ -19,7 +19,7 @@ extern SEXP vflatten_impl(SEXP, SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
   {"coerce_impl",           (DL_FUNC) &coerce_impl,    2},
-  {"pluck_impl",            (DL_FUNC) &pluck_impl,   5},
+  {"pluck_impl",            (DL_FUNC) &pluck_impl,     5},
   {"flatten_impl",          (DL_FUNC) &flatten_impl,   1},
   {"map_impl",              (DL_FUNC) &map_impl,       7},
   {"map2_impl",             (DL_FUNC) &map2_impl,      7},

--- a/src/init.c
+++ b/src/init.c
@@ -14,9 +14,9 @@ SEXP purrr_init_library(SEXP);
 extern SEXP coerce_impl(SEXP, SEXP);
 extern SEXP pluck_impl(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP flatten_impl(SEXP);
-extern SEXP map_impl(SEXP, SEXP, SEXP, SEXP);
-extern SEXP map2_impl(SEXP, SEXP, SEXP, SEXP);
-extern SEXP pmap_impl(SEXP, SEXP, SEXP, SEXP);
+extern SEXP map_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP map2_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP pmap_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP transpose_impl(SEXP, SEXP);
 extern SEXP vflatten_impl(SEXP, SEXP);
 
@@ -25,9 +25,9 @@ static const R_CallMethodDef CallEntries[] = {
   {"coerce_impl",           (DL_FUNC) &coerce_impl,    2},
   {"pluck_impl",            (DL_FUNC) &pluck_impl,   5},
   {"flatten_impl",          (DL_FUNC) &flatten_impl,   1},
-  {"map_impl",              (DL_FUNC) &map_impl,       4},
-  {"map2_impl",             (DL_FUNC) &map2_impl,      4},
-  {"pmap_impl",             (DL_FUNC) &pmap_impl,      4},
+  {"map_impl",              (DL_FUNC) &map_impl,       7},
+  {"map2_impl",             (DL_FUNC) &map2_impl,      7},
+  {"pmap_impl",             (DL_FUNC) &pmap_impl,      9},
   {"transpose_impl",        (DL_FUNC) &transpose_impl, 2},
   {"vflatten_impl",         (DL_FUNC) &vflatten_impl,  2},
   {"purrr_eval",            (DL_FUNC) &Rf_eval,        2},

--- a/src/map.c
+++ b/src/map.c
@@ -16,7 +16,6 @@ SEXP call_loop(SEXP env,
                int n,
                SEXP names,
                int* p_i,
-               SEXP error_call,
                int force) {
   SEXP bar = PROTECT(cli_progress_bar(n, progress));
 
@@ -55,8 +54,7 @@ SEXP map_impl(SEXP env,
               SEXP progress,
               SEXP ffi_n,
               SEXP names,
-              SEXP i,
-              SEXP error_call) {
+              SEXP i) {
   static SEXP call = NULL;
   if (call == NULL) {
     SEXP x_sym = Rf_install(".x");
@@ -87,7 +85,6 @@ SEXP map_impl(SEXP env,
     n,
     names,
     p_i,
-    error_call,
     force
   );
 }
@@ -97,8 +94,7 @@ SEXP map2_impl(SEXP env,
                SEXP progress,
                SEXP ffi_n,
                SEXP names,
-               SEXP i,
-               SEXP error_call) {
+               SEXP i) {
   static SEXP call = NULL;
   if (call == NULL) {
     SEXP x_sym = Rf_install(".x");
@@ -129,7 +125,6 @@ SEXP map2_impl(SEXP env,
     n,
     names,
     p_i,
-    error_call,
     force
   );
 }
@@ -141,8 +136,7 @@ SEXP pmap_impl(SEXP env,
                SEXP names,
                SEXP i,
                SEXP call_names,
-               SEXP ffi_call_n,
-               SEXP error_call) {
+               SEXP ffi_call_n) {
   // Construct call like f(.l[[1]][[i]], .l[[2]][[i]], ...)
   //
   // Currently accessing S3 vectors in a list like .l[[c(1, i)]] will not
@@ -199,7 +193,6 @@ SEXP pmap_impl(SEXP env,
     n,
     names,
     p_i,
-    error_call,
     force
   );
 

--- a/src/map.c
+++ b/src/map.c
@@ -9,25 +9,31 @@
 #include "cli/progress.h"
 
 // call must involve i
-SEXP call_loop(SEXP env, SEXP call, int n, SEXPTYPE type, int force_args,
-               SEXP progress) {
-  SEXP i = Rf_install("i");
-  SEXP i_val = Rf_findVarInFrame(env, i);
-
+SEXP call_loop(SEXP env,
+               SEXP call,
+               SEXPTYPE type,
+               SEXP progress,
+               int n,
+               SEXP names,
+               int* p_i,
+               SEXP error_call,
+               int force) {
   SEXP bar = PROTECT(cli_progress_bar(n, progress));
 
   SEXP out = PROTECT(Rf_allocVector(type, n));
-  SEXP names_val = Rf_findVarInFrame(env, R_NamesSymbol);
-  Rf_setAttrib(out, R_NamesSymbol, names_val);
+  Rf_setAttrib(out, R_NamesSymbol, names);
 
   for (int i = 0; i < n; ++i) {
-    if (CLI_SHOULD_TICK) cli_progress_set(bar, i);
-    if (i % 1024 == 0)
+    *p_i = i + 1;
+
+    if (CLI_SHOULD_TICK) {
+      cli_progress_set(bar, i);
+    }
+    if (i % 1024 == 0) {
       R_CheckUserInterrupt();
+    }
 
-    INTEGER(i_val)[0] = i + 1;
-
-    SEXP res = PROTECT(R_forceAndCall(call, force_args, env));
+    SEXP res = PROTECT(R_forceAndCall(call, force, env));
 
     if (type != VECSXP && Rf_length(res) != 1) {
       Rf_errorcall(R_NilValue, "Result must be length 1, not %i.", Rf_length(res));
@@ -37,77 +43,106 @@ SEXP call_loop(SEXP env, SEXP call, int n, SEXPTYPE type, int force_args,
     UNPROTECT(1);
   }
 
-  INTEGER(i_val)[0] = 0;
+  *p_i = 0;
   cli_progress_done(bar);
 
   UNPROTECT(2);
   return out;
 }
 
-SEXP map_impl(SEXP env, SEXP type_, SEXP progress, SEXP error_call) {
-  static SEXP f_call = NULL;
-  if (f_call == NULL) {
-    SEXP x = Rf_install(".x");
-    SEXP f = Rf_install(".f");
-    SEXP i = Rf_install("i");
+SEXP map_impl(SEXP env,
+              SEXP ffi_type,
+              SEXP progress,
+              SEXP ffi_n,
+              SEXP names,
+              SEXP i,
+              SEXP error_call) {
+  static SEXP call = NULL;
+  if (call == NULL) {
+    SEXP x_sym = Rf_install(".x");
+    SEXP f_sym = Rf_install(".f");
+    SEXP i_sym = Rf_install("i");
 
     // Constructs a call like f(x[[i]], ...) - don't want to substitute
     // actual values for f or x, because they may be long, which creates
     // bad tracebacks()
-    SEXP Xi = PROTECT(Rf_lang3(R_Bracket2Symbol, x, i));
-    f_call = PROTECT(Rf_lang3(f, Xi, R_DotsSymbol));
+    SEXP x_i_sym = PROTECT(Rf_lang3(R_Bracket2Symbol, x_sym, i_sym));
 
-    R_PreserveObject(f_call);
+    call = Rf_lang3(f_sym, x_i_sym, R_DotsSymbol);
+    R_PreserveObject(call);
+
+    UNPROTECT(1);
+  }
+
+  SEXPTYPE type = Rf_str2type(CHAR(STRING_ELT(ffi_type, 0)));
+  int n = INTEGER_ELT(ffi_n, 0);
+  int* p_i = INTEGER(i);
+  int force = 1;
+
+  return call_loop(
+    env,
+    call,
+    type,
+    progress,
+    n,
+    names,
+    p_i,
+    error_call,
+    force
+  );
+}
+
+SEXP map2_impl(SEXP env,
+               SEXP ffi_type,
+               SEXP progress,
+               SEXP ffi_n,
+               SEXP names,
+               SEXP i,
+               SEXP error_call) {
+  static SEXP call = NULL;
+  if (call == NULL) {
+    SEXP x_sym = Rf_install(".x");
+    SEXP y_sym = Rf_install(".y");
+    SEXP f_sym = Rf_install(".f");
+    SEXP i_sym = Rf_install("i");
+
+    // Constructs a call like f(x[[i]], y[[i]], ...)
+    SEXP x_i_sym = PROTECT(Rf_lang3(R_Bracket2Symbol, x_sym, i_sym));
+    SEXP y_i_sym = PROTECT(Rf_lang3(R_Bracket2Symbol, y_sym, i_sym));
+
+    call = Rf_lang4(f_sym, x_i_sym, y_i_sym, R_DotsSymbol);
+    R_PreserveObject(call);
+
     UNPROTECT(2);
   }
 
-  SEXP n = Rf_install("n");
-  int n_val = INTEGER(Rf_findVarInFrame(env, n))[0];
+  SEXPTYPE type = Rf_str2type(CHAR(STRING_ELT(ffi_type, 0)));
+  int n = INTEGER_ELT(ffi_n, 0);
+  int* p_i = INTEGER(i);
+  int force = 2;
 
-  SEXPTYPE type = Rf_str2type(CHAR(Rf_asChar(type_)));
-
-  return call_loop(env, f_call, n_val, type, 1, progress);
+  return call_loop(
+    env,
+    call,
+    type,
+    progress,
+    n,
+    names,
+    p_i,
+    error_call,
+    force
+  );
 }
 
-SEXP map2_impl(SEXP env, SEXP type_, SEXP progress, SEXP error_call) {
-  static SEXP f_call = NULL;
-  if (f_call == NULL) {
-    SEXP x = Rf_install(".x");
-    SEXP y = Rf_install(".y");
-    SEXP f = Rf_install(".f");
-    SEXP i = Rf_install("i");
-
-    // Constructs a call like f(x[[i]], y[[i]], ...)
-    SEXP Xi = PROTECT(Rf_lang3(R_Bracket2Symbol, x, i));
-    SEXP Yi = PROTECT(Rf_lang3(R_Bracket2Symbol, y, i));
-    f_call = PROTECT(Rf_lang4(f, Xi, Yi, R_DotsSymbol));
-
-    R_PreserveObject(f_call);
-    UNPROTECT(3);
-  }
-
-  SEXP n = Rf_install("n");
-  int n_val = INTEGER(Rf_findVarInFrame(env, n))[0];
-
-  SEXPTYPE type = Rf_str2type(CHAR(Rf_asChar(type_)));
-
-  return call_loop(env, f_call, n_val, type, 2, progress);
-}
-
-SEXP pmap_impl(SEXP env, SEXP type_, SEXP progress, SEXP error_call) {
-  SEXP l = Rf_install(".l");
-  SEXP l_val = PROTECT(Rf_findVarInFrame(env, l));
-  SEXPTYPE type = Rf_str2type(CHAR(Rf_asChar(type_)));
-
-  SEXP l_names = PROTECT(Rf_getAttrib(l_val, R_NamesSymbol));
-  int has_names = !Rf_isNull(l_names);
-
-  SEXP f = Rf_install(".f");
-  SEXP i = Rf_install("i");
-
-  SEXP n = Rf_install("n");
-  int n_val = INTEGER(Rf_findVarInFrame(env, n))[0];
-
+SEXP pmap_impl(SEXP env,
+               SEXP ffi_type,
+               SEXP progress,
+               SEXP ffi_n,
+               SEXP names,
+               SEXP i,
+               SEXP call_names,
+               SEXP ffi_call_n,
+               SEXP error_call) {
   // Construct call like f(.l[[1]][[i]], .l[[2]][[i]], ...)
   //
   // Currently accessing S3 vectors in a list like .l[[c(1, i)]] will not
@@ -116,29 +151,58 @@ SEXP pmap_impl(SEXP env, SEXP type_, SEXP progress, SEXP error_call) {
   // We construct the call backwards because can only add to the front of a
   // linked list. That makes PROTECTion tricky because we need to update it
   // each time to point to the start of the linked list.
+  SEXP l_sym = Rf_install(".l");
+  SEXP f_sym = Rf_install(".f");
+  SEXP i_sym = Rf_install("i");
 
-  SEXP f_call = Rf_lang1(R_DotsSymbol);
-  PROTECT_INDEX fi;
-  PROTECT_WITH_INDEX(f_call, &fi);
+  SEXP call = Rf_lang1(R_DotsSymbol);
+  PROTECT_INDEX call_shelter;
+  PROTECT_WITH_INDEX(call, &call_shelter);
 
-  int m = Rf_length(l_val);
+  bool has_call_names = call_names != R_NilValue;
+  const SEXP* v_call_names = has_call_names ? STRING_PTR(call_names) : NULL;
+  int call_n = INTEGER_ELT(ffi_call_n, 0);
 
-  for (int j = m - 1; j >= 0; --j) {
+  for (int j = call_n - 1; j >= 0; --j) {
     // Construct call like .l[[j]][[i]]
-    SEXP j_ = PROTECT(Rf_ScalarInteger(j + 1));
-    SEXP l_j = PROTECT(Rf_lang3(R_Bracket2Symbol, l, j_));
-    SEXP l_ji = PROTECT(Rf_lang3(R_Bracket2Symbol, l_j, i));
+    SEXP j_val = PROTECT(Rf_ScalarInteger(j + 1));
+    SEXP l_j_sym = PROTECT(Rf_lang3(R_Bracket2Symbol, l_sym, j_val));
+    SEXP l_j_i_sym = PROTECT(Rf_lang3(R_Bracket2Symbol, l_j_sym, i_sym));
 
-    REPROTECT(f_call = Rf_lcons(l_ji, f_call), fi);
-    if (has_names && CHAR(STRING_ELT(l_names, j))[0] != '\0')
-      SET_TAG(f_call, Rf_install(CHAR(STRING_ELT(l_names, j))));
+    call = Rf_lcons(l_j_i_sym, call);
+    REPROTECT(call, call_shelter);
+
+    if (has_call_names) {
+      const char* call_name = CHAR(v_call_names[j]);
+
+      if (call_name[0] != '\0') {
+        SET_TAG(call, Rf_install(call_name));
+      }
+    }
 
     UNPROTECT(3);
   }
 
-  REPROTECT(f_call = Rf_lcons(f, f_call), fi);
+  call = Rf_lcons(f_sym, call);
+  REPROTECT(call, call_shelter);
 
-  SEXP out = call_loop(env, f_call, n_val, type, m, progress);
-  UNPROTECT(3);
+  SEXPTYPE type = Rf_str2type(CHAR(STRING_ELT(ffi_type, 0)));
+  int n = INTEGER_ELT(ffi_n, 0);
+  int* p_i = INTEGER(i);
+  int force = call_n;
+
+  SEXP out = call_loop(
+    env,
+    call,
+    type,
+    progress,
+    n,
+    names,
+    p_i,
+    error_call,
+    force
+  );
+
+  UNPROTECT(1);
   return out;
 }

--- a/src/map.h
+++ b/src/map.h
@@ -7,8 +7,7 @@ extern "C" {
                 SEXP progress,
                 SEXP ffi_n,
                 SEXP names,
-                SEXP i,
-                SEXP error_call);
+                SEXP i);
 
   SEXP pmap_impl(SEXP env,
                  SEXP ffi_type,
@@ -17,8 +16,7 @@ extern "C" {
                  SEXP names,
                  SEXP i,
                  SEXP call_names,
-                 SEXP ffi_call_n,
-                 SEXP error_call);
+                 SEXP ffi_call_n);
 }
 
 #endif

--- a/src/map.h
+++ b/src/map.h
@@ -2,8 +2,23 @@
 #define MAP_H
 
 extern "C" {
-  SEXP map_impl(SEXP env, SEXP x_name_, SEXP f_name_, SEXP type_, SEXP progress);
-  SEXP pmap_impl(SEXP env, SEXP l_name_, SEXP f_name_, SEXP type_, SEXP progress);
+  SEXP map_impl(SEXP env,
+                SEXP ffi_type,
+                SEXP progress,
+                SEXP ffi_n,
+                SEXP names,
+                SEXP i,
+                SEXP error_call);
+
+  SEXP pmap_impl(SEXP env,
+                 SEXP ffi_type,
+                 SEXP progress,
+                 SEXP ffi_n,
+                 SEXP names,
+                 SEXP i,
+                 SEXP call_names,
+                 SEXP ffi_call_n,
+                 SEXP error_call);
 }
 
 #endif

--- a/src/utils.c
+++ b/src/utils.c
@@ -51,5 +51,3 @@ SEXP lang8(SEXP s, SEXP t, SEXP u, SEXP v, SEXP w, SEXP x, SEXP y, SEXP z) {
   UNPROTECT(1);
   return s;
 }
-
-#include <vctrs.c>

--- a/src/utils.h
+++ b/src/utils.h
@@ -2,7 +2,6 @@
 #define UTILS_H
 
 #include <stdbool.h>
-#include <vctrs.h>
 
 
 SEXP sym_protect(SEXP x);


### PR DESCRIPTION
- Biggest change is no more `Rf_findVarInFrame()`, passing through explicit arguments instead, which feels less magical
- We also don't need to pass `error_call` through at all because we didn't actually use it in the C code (this is also nice because it avoids forcing the `error_call` promise unless it is actually needed)
- Unlinked from vctrs C API
- Modernized naming conventions and some syntax

Otherwise no change in behavior at all