### PR TITLE
Coercion deprecation improvements

### DIFF
--- a/R/coerce.R
+++ b/R/coerce.R
@@ -23,9 +23,9 @@ deprecate_to_char <- function(type) {
   )
 }
 
-local_deprecation_user_env <- function(frame = caller_env()) {
+local_deprecation_user_env <- function(user_env = caller_env(2), frame = caller_env()) {
   local_bindings(
-    deprecation_user_env = frame,
+    deprecation_user_env = user_env,
     .env = the,
     .frame = frame
   )

--- a/R/coerce.R
+++ b/R/coerce.R
@@ -7,15 +7,26 @@ coerce <- function(x, type) {
 coerce_lgl <- function(x) coerce(x, "logical")
 coerce_int <- function(x) coerce(x, "integer")
 coerce_dbl <- function(x) coerce(x, "double")
-coerce_chr <- function(x) coerce(x, "character")
+coerce_chr <- function(x) {
+  local_deprecation_user_env()
+  coerce(x, "character")
+}
 
 
-deprecate_to_char <- function(type, call = caller_env()) {
+deprecate_to_char <- function(type) {
   lifecycle::deprecate_warn(
     "1.0.0",
     I(paste0("Automatic coercion from ", type, " to character")),
     I("an explicit call to as.character() within map_chr()"),
     always = TRUE,
-    user_env = call
+    user_env = the$deprecation_user_env
+  )
+}
+
+local_deprecation_user_env <- function(frame = caller_env()) {
+  local_bindings(
+    deprecation_user_env = frame,
+    .env = the,
+    .frame = frame
   )
 }

--- a/R/coerce.R
+++ b/R/coerce.R
@@ -17,7 +17,7 @@ deprecate_to_char <- function(type) {
   lifecycle::deprecate_warn(
     "1.0.0",
     I(paste0("Automatic coercion from ", type, " to character")),
-    I("an explicit call to as.character() within map_chr()"),
+    I("an explicit call to `as.character()` within `map_chr()`"),
     always = TRUE,
     user_env = the$deprecation_user_env
   )

--- a/R/map.R
+++ b/R/map.R
@@ -147,6 +147,7 @@ map_dbl <- function(.x, .f, ..., .progress = FALSE) {
 #' @rdname map
 #' @export
 map_chr <- function(.x, .f, ..., .progress = FALSE) {
+  local_deprecation_user_env()
   map_("character", .x, .f, ..., .progress = .progress)
 }
 

--- a/R/package-purrr.R
+++ b/R/package-purrr.R
@@ -5,3 +5,5 @@
 #' @importFrom lifecycle deprecated
 #' @useDynLib purrr, .registration = TRUE
 "_PACKAGE"
+
+the <- new_environment()

--- a/src/coerce.c
+++ b/src/coerce.c
@@ -62,14 +62,13 @@ double integer_to_real(int x) {
 }
 
 void deprecate_to_char(const char* type_char) {
-  SEXP env = PROTECT(current_env());
   SEXP type = PROTECT(Rf_mkString(type_char));
 
   SEXP fun = PROTECT(Rf_lang3(Rf_install(":::"), Rf_install("purrr"), Rf_install("deprecate_to_char")));
-  SEXP call = PROTECT(Rf_lang3(fun, type, env));
+  SEXP call = PROTECT(Rf_lang2(fun, type));
 
   Rf_eval(call, R_GlobalEnv);
-  UNPROTECT(4);
+  UNPROTECT(3);
 }
 
 SEXP logical_to_char(int x, SEXP from, SEXP to, int i) {

--- a/src/coerce.c
+++ b/src/coerce.c
@@ -61,15 +61,15 @@ double integer_to_real(int x) {
   return (x == NA_INTEGER) ? NA_REAL : x;
 }
 
-void deprecate_to_char(const char* type) {
-  SEXP call = PROTECT(Rf_lang2(
-    Rf_install("deprecate_to_char"),
-    PROTECT(Rf_mkString("type"))
-  ));
+void deprecate_to_char(const char* type_char) {
   SEXP env = PROTECT(caller_env());
+  SEXP type = PROTECT(Rf_mkString(type_char));
 
-  Rf_eval(call, env);
-  UNPROTECT(3);
+  SEXP fun = PROTECT(Rf_lang3(Rf_install(":::"), Rf_install("purrr"), Rf_install("deprecate_to_char")));
+  SEXP call = PROTECT(Rf_lang3(fun, type, env));
+
+  Rf_eval(call, R_GetCurrentEnv());
+  UNPROTECT(4);
 }
 
 SEXP logical_to_char(int x, SEXP from, SEXP to, int i) {

--- a/src/coerce.c
+++ b/src/coerce.c
@@ -62,13 +62,13 @@ double integer_to_real(int x) {
 }
 
 void deprecate_to_char(const char* type_char) {
-  SEXP env = PROTECT(caller_env());
+  SEXP env = PROTECT(current_env());
   SEXP type = PROTECT(Rf_mkString(type_char));
 
   SEXP fun = PROTECT(Rf_lang3(Rf_install(":::"), Rf_install("purrr"), Rf_install("deprecate_to_char")));
   SEXP call = PROTECT(Rf_lang3(fun, type, env));
 
-  Rf_eval(call, R_GetCurrentEnv());
+  Rf_eval(call, R_GlobalEnv);
   UNPROTECT(4);
 }
 

--- a/src/conditions.c
+++ b/src/conditions.c
@@ -3,7 +3,7 @@
 #include "utils.h"
 #include <R_ext/Parse.h>
 
-SEXP caller_env() {
+SEXP current_env() {
   ParseStatus status;
   SEXP code = PROTECT(Rf_mkString("as.call(list(sys.frame, -1))"));
   SEXP parsed = PROTECT(R_ParseVector(code, -1, &status, R_NilValue));
@@ -46,7 +46,7 @@ void r_abort(const char* fmt, ...) {
   va_end(dots);
   buf[BUFSIZE - 1] = '\0';
 
-  SEXP env = PROTECT(caller_env());
+  SEXP env = PROTECT(current_env());
   r_abort0(env, buf);
 }
 
@@ -89,7 +89,7 @@ void stop_bad_type(SEXP x, const char* expected, const char* what, const char* a
   node = CDR(node);
   SET_TAG(node, Rf_install("arg"));
 
-  SEXP env = PROTECT(caller_env());
+  SEXP env = PROTECT(current_env());
   Rf_eval(call, env);
   while (1); // No return
 }
@@ -114,7 +114,7 @@ void stop_bad_element_type(SEXP x, R_xlen_t index, const char* expected, const c
   node = CDR(node);
   SET_TAG(node, Rf_install("arg"));
 
-  SEXP env = PROTECT(caller_env());
+  SEXP env = PROTECT(current_env());
   Rf_eval(call, env);
   while (1); // No return
 }
@@ -148,7 +148,7 @@ void stop_bad_element_length(SEXP x,
   node = CDR(node);
   SET_TAG(node, Rf_install("recycle"));
 
-  SEXP env = PROTECT(caller_env());
+  SEXP env = PROTECT(current_env());
   Rf_eval(call, env);
   while (1); // No return
 }

--- a/src/conditions.h
+++ b/src/conditions.h
@@ -6,7 +6,7 @@
 void __attribute__ ((noreturn)) stop_bad_type(SEXP x, const char* expected, const char* what, const char* arg) __attribute__((noreturn));
 void __attribute__ ((noreturn)) stop_bad_element_type(SEXP x, R_xlen_t index, const char* expected, const char* what, const char* arg) __attribute__((noreturn));
 void __attribute__ ((noreturn)) stop_bad_element_length(SEXP x, R_xlen_t index, R_xlen_t expected_length, const char* what, const char* arg, bool recycle) __attribute__((noreturn));
-SEXP caller_env();
+SEXP current_env();
 void __attribute__ ((noreturn)) r_abort(const char* fmt, ...);
 void __attribute__ ((noreturn)) r_abort_call(SEXP env, const char* fmt, ...);
 

--- a/tests/testthat/_snaps/coerce.md
+++ b/tests/testthat/_snaps/coerce.md
@@ -23,6 +23,10 @@
 
     Code
       map_chr(1:4, identity)
+    Condition
+      Warning:
+      Automatic coercion from integer to character was deprecated in purrr 1.0.0.
+      i Please use an explicit call to as.character() within map_chr() instead.
     Output
       [1] "1" "2" "3" "4"
 

--- a/tests/testthat/_snaps/coerce.md
+++ b/tests/testthat/_snaps/coerce.md
@@ -4,18 +4,25 @@
       expect_equal(coerce_chr(TRUE), "TRUE")
     Condition
       Warning:
-      Automatic coercion from type to character was deprecated in purrr 1.0.0.
+      Automatic coercion from logical to character was deprecated in purrr 1.0.0.
       i Please use an explicit call to as.character() within map_chr() instead.
     Code
       expect_equal(coerce_chr(1L), "1")
     Condition
       Warning:
-      Automatic coercion from type to character was deprecated in purrr 1.0.0.
+      Automatic coercion from integer to character was deprecated in purrr 1.0.0.
       i Please use an explicit call to as.character() within map_chr() instead.
     Code
       expect_equal(coerce_chr(1.5), "1.500000")
     Condition
       Warning:
-      Automatic coercion from type to character was deprecated in purrr 1.0.0.
+      Automatic coercion from double to character was deprecated in purrr 1.0.0.
       i Please use an explicit call to as.character() within map_chr() instead.
+
+# error captures correct env
+
+    Code
+      map_chr(1:4, identity)
+    Output
+      [1] "1" "2" "3" "4"
 

--- a/tests/testthat/_snaps/coerce.md
+++ b/tests/testthat/_snaps/coerce.md
@@ -5,19 +5,19 @@
     Condition
       Warning:
       Automatic coercion from logical to character was deprecated in purrr 1.0.0.
-      i Please use an explicit call to as.character() within map_chr() instead.
+      i Please use an explicit call to `as.character()` within `map_chr()` instead.
     Code
       expect_equal(coerce_chr(1L), "1")
     Condition
       Warning:
       Automatic coercion from integer to character was deprecated in purrr 1.0.0.
-      i Please use an explicit call to as.character() within map_chr() instead.
+      i Please use an explicit call to `as.character()` within `map_chr()` instead.
     Code
       expect_equal(coerce_chr(1.5), "1.500000")
     Condition
       Warning:
       Automatic coercion from double to character was deprecated in purrr 1.0.0.
-      i Please use an explicit call to as.character() within map_chr() instead.
+      i Please use an explicit call to `as.character()` within `map_chr()` instead.
 
 # error captures correct env
 
@@ -26,7 +26,7 @@
     Condition
       Warning:
       Automatic coercion from integer to character was deprecated in purrr 1.0.0.
-      i Please use an explicit call to as.character() within map_chr() instead.
+      i Please use an explicit call to `as.character()` within `map_chr()` instead.
     Output
       [1] "1" "2" "3" "4"
 

--- a/tests/testthat/_snaps/coerce.md
+++ b/tests/testthat/_snaps/coerce.md
@@ -29,4 +29,8 @@
       i Please use an explicit call to `as.character()` within `map_chr()` instead.
     Output
       [1] "1" "2" "3" "4"
+    Code
+      indirect()
+    Output
+      [1] "1" "2" "3" "4"
 

--- a/tests/testthat/test-coerce.R
+++ b/tests/testthat/test-coerce.R
@@ -44,7 +44,16 @@ test_that("can coerce to character vectors", {
 })
 
 test_that("error captures correct env", {
-  expect_snapshot(map_chr(1:4, identity))
+  indirect <- function() {
+    purrr::map_chr(1:4, identity)
+  }
+  environment(indirect) <- ns_env("rlang")
+
+  expect_snapshot({
+    map_chr(1:4, identity)
+    indirect()
+  })
+
 })
 
 test_that("warns once per vector", {

--- a/tests/testthat/test-coerce.R
+++ b/tests/testthat/test-coerce.R
@@ -43,6 +43,10 @@ test_that("can coerce to character vectors", {
   expect_equal(coerce_chr("x"), "x")
 })
 
+test_that("error captures correct env", {
+  expect_snapshot(map_chr(1:4, identity))
+})
+
 test_that("warns once per vector", {
   expect_warning(expect_warning(coerce_chr(1:5)), NA)
 })


### PR DESCRIPTION
* Use `type` not `"type"`
* Call `purrr:::deprecate_to_char()`
* Capture correct environment

Fixes #976