### PR TITLE
Use .purrr_ prefix for internal helpers

### DIFF
--- a/R/lmap.R
+++ b/R/lmap.R
@@ -61,7 +61,12 @@ lmap_at <- function(.x, .at, .f, ...) {
   lmap_helper(.x, where, .f, ...)
 }
 
-lmap_helper <- function(.x, .ind, .f, ..., .else = NULL, .purrr_error_call = caller_env()) {
+lmap_helper <- function(.x,
+                        .ind,
+                        .f,
+                        ...,
+                        .else = NULL,
+                        .purrr_error_call = caller_env()) {
   .f <- rlang::as_function(.f, call = .purrr_error_call)
   if (!is.null(.else)) {
     .else <- rlang::as_function(.else, call = .purrr_error_call)

--- a/R/lmap.R
+++ b/R/lmap.R
@@ -61,10 +61,10 @@ lmap_at <- function(.x, .at, .f, ...) {
   lmap_helper(.x, where, .f, ...)
 }
 
-lmap_helper <- function(.x, .ind, .f, ..., .else = NULL, .error_call = caller_env()) {
-  .f <- rlang::as_function(.f, call = .error_call)
+lmap_helper <- function(.x, .ind, .f, ..., .else = NULL, .purrr_error_call = caller_env()) {
+  .f <- rlang::as_function(.f, call = .purrr_error_call)
   if (!is.null(.else)) {
-    .else <- rlang::as_function(.else, call = .error_call)
+    .else <- rlang::as_function(.else, call = .purrr_error_call)
   }
 
   out <- vector("list", length(.x))
@@ -80,7 +80,7 @@ lmap_helper <- function(.x, .ind, .f, ..., .else = NULL, .error_call = caller_en
     if (!is.list(res)) {
       cli::cli_abort(
         "{.code .f(.x[[{i}]])} must return a list, not {.obj_type_friendly {res}}.",
-        call = .error_call
+        call = .purrr_error_call
       )
     }
     out[[i]] <- res

--- a/R/map-depth.R
+++ b/R/map-depth.R
@@ -93,7 +93,7 @@ map_depth_rec <- function(.fmap,
                           ...,
                           .ragged,
                           .is_node,
-                          .error_call = caller_env()) {
+                          .purrr_error_call = caller_env()) {
   if (.depth == 0) {
     if (identical(.fmap, map)) {
       return(.f(.x, ...))
@@ -107,7 +107,7 @@ map_depth_rec <- function(.fmap,
     if (.ragged) {
       return(.fmap(.x, .f, ...))
     } else {
-      cli::cli_abort("List not deep enough", call = .error_call)
+      cli::cli_abort("List not deep enough", call = .purrr_error_call)
     }
   }
 
@@ -123,7 +123,7 @@ map_depth_rec <- function(.fmap,
         ...,
         .ragged = .ragged,
         .is_node = .is_node,
-        .error_call = .error_call
+        .purrr_error_call = .purrr_error_call
       )
     })
   }

--- a/R/map.R
+++ b/R/map.R
@@ -151,7 +151,12 @@ map_chr <- function(.x, .f, ..., .progress = FALSE) {
   map_("character", .x, .f, ..., .progress = .progress)
 }
 
-map_ <- function(.type, .x, .f, ..., .progress = FALSE, .purrr_error_call = caller_env()) {
+map_ <- function(.type,
+                 .x,
+                 .f,
+                 ...,
+                 .progress = FALSE,
+                 .purrr_error_call = caller_env()) {
   .x <- vctrs_vec_compat(.x)
   vec_assert(.x, arg = ".x", call = .purrr_error_call)
 

--- a/R/map.R
+++ b/R/map.R
@@ -151,9 +151,9 @@ map_chr <- function(.x, .f, ..., .progress = FALSE) {
   map_("character", .x, .f, ..., .progress = .progress)
 }
 
-map_ <- function(.type, .x, .f, ..., .progress = FALSE, ..error_call = caller_env()) {
+map_ <- function(.type, .x, .f, ..., .progress = FALSE, .purrr_error_call = caller_env()) {
   .x <- vctrs_vec_compat(.x)
-  vec_assert(.x, arg = ".x", call = ..error_call)
+  vec_assert(.x, arg = ".x", call = .purrr_error_call)
 
   n <- vec_size(.x)
 
@@ -164,7 +164,7 @@ map_ <- function(.type, .x, .f, ..., .progress = FALSE, ..error_call = caller_en
   i <- 0L
   with_indexed_errors(
     i = i,
-    error_call = ..error_call,
+    error_call = .purrr_error_call,
     .Call(map_impl, environment(), .type, .progress, n, names, i)
   )
 }

--- a/R/map2.R
+++ b/R/map2.R
@@ -54,12 +54,12 @@ map2_chr <- function(.x, .y, .f, ..., .progress = FALSE) {
   map2_("character", .x, .y, .f, ..., .progress = .progress)
 }
 
-map2_ <- function(.type, .x, .y, .f, ..., .progress = FALSE, ..error_call = caller_env()) {
+map2_ <- function(.type, .x, .y, .f, ..., .progress = FALSE, .purrr_error_call = caller_env()) {
   .x <- vctrs_vec_compat(.x)
   .y <- vctrs_vec_compat(.y)
 
-  n <- vec_size_common(.x = .x, .y = .y, .call = ..error_call)
-  args <- vec_recycle_common(.x = .x, .y = .y, .size = n, .call = ..error_call)
+  n <- vec_size_common(.x = .x, .y = .y, .call = .purrr_error_call)
+  args <- vec_recycle_common(.x = .x, .y = .y, .size = n, .call = .purrr_error_call)
   .x <- args$.x
   .y <- args$.y
 
@@ -70,7 +70,7 @@ map2_ <- function(.type, .x, .y, .f, ..., .progress = FALSE, ..error_call = call
   i <- 0L
   with_indexed_errors(
     i = i,
-    error_call = ..error_call,
+    error_call = .purrr_error_call,
     .Call(map2_impl, environment(), .type, .progress, n, names, i)
   )
 }

--- a/R/map2.R
+++ b/R/map2.R
@@ -54,7 +54,13 @@ map2_chr <- function(.x, .y, .f, ..., .progress = FALSE) {
   map2_("character", .x, .y, .f, ..., .progress = .progress)
 }
 
-map2_ <- function(.type, .x, .y, .f, ..., .progress = FALSE, .purrr_error_call = caller_env()) {
+map2_ <- function(.type,
+                  .x,
+                  .y,
+                  .f,
+                  ...,
+                  .progress = FALSE,
+                  .purrr_error_call = caller_env()) {
   .x <- vctrs_vec_compat(.x)
   .y <- vctrs_vec_compat(.y)
 

--- a/R/modify-tree.R
+++ b/R/modify-tree.R
@@ -70,8 +70,8 @@ as_is_node <- function(f, error_call = caller_env(), error_arg = caller_arg(f)) 
     as_predicate(
       is_node_f,
       .mapper = FALSE,
-      .error_call = error_call,
-      .error_arg = error_arg
+      .purrr_error_call = error_call,
+      .purrr_error_arg = error_arg
     )
   }
 }

--- a/R/pmap.R
+++ b/R/pmap.R
@@ -99,7 +99,12 @@ pmap_chr <- function(.l, .f, ..., .progress = FALSE) {
   pmap_("character", .l, .f, ..., .progress = .progress)
 }
 
-pmap_ <- function(.type, .l, .f, ..., .progress = FALSE, .purrr_error_call = caller_env()) {
+pmap_ <- function(.type,
+                  .l,
+                  .f,
+                  ...,
+                  .progress = FALSE,
+                  .purrr_error_call = caller_env()) {
   .l <- vctrs_list_compat(.l, error_call = .purrr_error_call)
   .l <- map(.l, vctrs_vec_compat)
 

--- a/R/pmap.R
+++ b/R/pmap.R
@@ -99,12 +99,12 @@ pmap_chr <- function(.l, .f, ..., .progress = FALSE) {
   pmap_("character", .l, .f, ..., .progress = .progress)
 }
 
-pmap_ <- function(.type, .l, .f, ..., .progress = FALSE, ..error_call = caller_env()) {
-  .l <- vctrs_list_compat(.l, error_call = ..error_call)
+pmap_ <- function(.type, .l, .f, ..., .progress = FALSE, .purrr_error_call = caller_env()) {
+  .l <- vctrs_list_compat(.l, error_call = .purrr_error_call)
   .l <- map(.l, vctrs_vec_compat)
 
-  n <- vec_size_common(!!!.l, .arg = ".l", .call = ..error_call)
-  .l <- vec_recycle_common(!!!.l, .size = n, .arg = ".l", .call = ..error_call)
+  n <- vec_size_common(!!!.l, .arg = ".l", .call = .purrr_error_call)
+  .l <- vec_recycle_common(!!!.l, .size = n, .arg = ".l", .call = .purrr_error_call)
 
   if (length(.l) > 0L) {
     names <- vec_names(.l[[1L]])
@@ -120,7 +120,7 @@ pmap_ <- function(.type, .l, .f, ..., .progress = FALSE, ..error_call = caller_e
   i <- 0L
   with_indexed_errors(
     i = i,
-    error_call = ..error_call,
+    error_call = .purrr_error_call,
     .Call(pmap_impl, environment(), .type, .progress, n, names, i, call_names, call_n)
   )
 }

--- a/R/reduce.R
+++ b/R/reduce.R
@@ -133,7 +133,13 @@ reduce2 <- function(.x, .y, .f, ..., .init) {
   reduce2_impl(.x, .y, .f, ..., .init = .init, .left = TRUE)
 }
 
-reduce_impl <- function(.x, .f, ..., .init, .dir, .acc = FALSE, .purrr_error_call = caller_env()) {
+reduce_impl <- function(.x,
+                        .f,
+                        ...,
+                        .init,
+                        .dir,
+                        .acc = FALSE,
+                        .purrr_error_call = caller_env()) {
   left <- arg_match(.dir, c("forward", "backward")) == "forward"
 
   out <- reduce_init(.x, .init, left = left, error_call = .purrr_error_call)
@@ -257,7 +263,14 @@ accum_index <- function(out, left) {
   }
 }
 
-reduce2_impl <- function(.x, .y, .f, ..., .init, .left = TRUE, .acc = FALSE, .purrr_error_call = caller_env()) {
+reduce2_impl <- function(.x,
+                         .y,
+                         .f,
+                         ...,
+                         .init,
+                         .left = TRUE,
+                         .acc = FALSE,
+                         .purrr_error_call = caller_env()) {
   out <- reduce_init(.x, .init, left = .left, error_call = .purrr_error_call)
   x_idx <- reduce_index(.x, .init, left = .left)
   y_idx <- reduce_index(.y, NULL, left = .left)

--- a/R/reduce.R
+++ b/R/reduce.R
@@ -133,10 +133,10 @@ reduce2 <- function(.x, .y, .f, ..., .init) {
   reduce2_impl(.x, .y, .f, ..., .init = .init, .left = TRUE)
 }
 
-reduce_impl <- function(.x, .f, ..., .init, .dir, .acc = FALSE, error_call = caller_env()) {
+reduce_impl <- function(.x, .f, ..., .init, .dir, .acc = FALSE, .purrr_error_call = caller_env()) {
   left <- arg_match(.dir, c("forward", "backward")) == "forward"
 
-  out <- reduce_init(.x, .init, left = left, error_call = error_call)
+  out <- reduce_init(.x, .init, left = left, error_call = .purrr_error_call)
   idx <- reduce_index(.x, .init, left = left)
 
   if (.acc) {
@@ -257,8 +257,8 @@ accum_index <- function(out, left) {
   }
 }
 
-reduce2_impl <- function(.x, .y, .f, ..., .init, .left = TRUE, .acc = FALSE, .error_call = caller_env()) {
-  out <- reduce_init(.x, .init, left = .left, error_call = .error_call)
+reduce2_impl <- function(.x, .y, .f, ..., .init, .left = TRUE, .acc = FALSE, .purrr_error_call = caller_env()) {
+  out <- reduce_init(.x, .init, left = .left, error_call = .purrr_error_call)
   x_idx <- reduce_index(.x, .init, left = .left)
   y_idx <- reduce_index(.y, NULL, left = .left)
 
@@ -266,7 +266,7 @@ reduce2_impl <- function(.x, .y, .f, ..., .init, .left = TRUE, .acc = FALSE, .er
     cli::cli_abort(
       "{.arg .y} must have length {length(x_idx)}, not {length(y_idx)}.",
       arg = ".y",
-      call = .error_call)
+      call = .purrr_error_call)
   }
 
   .f <- as_mapper(.f, ...)

--- a/R/utils.R
+++ b/R/utils.R
@@ -36,13 +36,13 @@ where_at <- function(x, at, error_arg = caller_arg(at), error_call = caller_env(
   }
 }
 
-where_if <- function(.x, .p, ..., .error_call = caller_env()) {
+where_if <- function(.x, .p, ..., .purrr_error_call = caller_env()) {
   if (is_logical(.p)) {
     stopifnot(length(.p) == length(.x))
     .p
   } else {
-    .p <- as_predicate(.p, ..., .mapper = TRUE, .error_call = NULL)
-    map_(.x, .p, ..., .type = "logical", ..error_call = .error_call)
+    .p <- as_predicate(.p, ..., .mapper = TRUE, .purrr_error_call = NULL)
+    map_(.x, .p, ..., .type = "logical", .purrr_error_call = .purrr_error_call)
   }
 }
 
@@ -50,11 +50,11 @@ as_predicate <- function(.fn,
                          ...,
                          .mapper,
                          .allow_na = FALSE,
-                         .error_call = caller_env(),
-                         .error_arg = caller_arg(.fn)) {
+                         .purrr_error_call = caller_env(),
+                         .purrr_error_arg = caller_arg(.fn)) {
 
-  force(.error_arg)
-  force(.error_call)
+  force(.purrr_error_call)
+  force(.purrr_error_arg)
 
   if (.mapper) {
     .fn <- as_mapper(.fn, ...)
@@ -69,9 +69,9 @@ as_predicate <- function(.fn,
         return(NA)
       }
       cli::cli_abort(
-        "{.fn { .error_arg }} must return a single `TRUE` or `FALSE`, not {.obj_type_friendly {out}}.",
-        arg = .error_arg,
-        call = .error_call
+        "{.fn { .purrr_error_arg }} must return a single `TRUE` or `FALSE`, not {.obj_type_friendly {out}}.",
+        arg = .purrr_error_arg,
+        call = .purrr_error_call
       )
     }
 


### PR DESCRIPTION
To avoid inadvertent matching to user supplied arguments. Fixes #1002.