### PR TITLE
Set `Biarch: true` for old R versions on Windows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,6 +34,7 @@ LinkingTo:
     cli
 VignetteBuilder: 
     knitr
+Biarch: true
 Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
 Encoding: UTF-8


### PR DESCRIPTION
Now that we have a `configure.win` script, we are forced to also set `Biarch: true` so that when purrr is installed from source on R < 4.2, it installs for both 32 and 64 bit Windows.

Otherwise, we get failures like this one in tidyr on our Windows 3.6 builds if we request `purrr (>= 1.0.0)`:
https://github.com/tidyverse/tidyr/actions/runs/3743952288/jobs/6356732834

```
*** arch - i386
Error: Error: package or namespace load failed for 'tidyr' in library.dynam(lib, package, package.lib):
 DLL 'purrr' not found: maybe not installed for this architecture?
```

This doesn't happen on newer versions of R because R 4.2 dropped support for 32 bit Windows. This is why windows-latest passes on tidyr.

See 6.3.4 of https://cran.r-project.org/doc/manuals/r-patched/R-admin.html for more details.

```
Windows
where there is a non-empty configure.win script, or a file src/Makefile.win (with some exceptions where the package is known to have an architecture-independent configure.win, or if --force-biarch or field ‘Biarch’ in the DESCRIPTION file is used to assert so).

In those cases only the current architecture is installed.
```

This might be important enough for a patch purrr release.