### PR TITLE
Fix `pluck_impl()` signature

### DIFF
--- a/R/pluck.R
+++ b/R/pluck.R
@@ -115,14 +115,13 @@ pluck_exists <- function(.x, ...) {
   !is_zap(pluck_raw(.x, list2(...), .default = zap()))
 }
 
-pluck_raw <- function(.x, index, .default = NULL, .error_call = caller_env()) {
+pluck_raw <- function(.x, index, .default = NULL) {
   .Call(
     pluck_impl,
     x = .x,
     index = index,
     missing = .default,
-    strict = FALSE,
-    error_call = .error_call
+    strict = FALSE
   )
 }
 
@@ -155,8 +154,7 @@ chuck <- function(.x, ...) {
     x = .x,
     index = list2(...),
     missing = NULL,
-    strict = TRUE,
-    error_call = current_env()
+    strict = TRUE
   )
 }
 

--- a/src/init.c
+++ b/src/init.c
@@ -9,7 +9,7 @@
 
 /* .Call calls */
 extern SEXP coerce_impl(SEXP, SEXP);
-extern SEXP pluck_impl(SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP pluck_impl(SEXP, SEXP, SEXP, SEXP);
 extern SEXP flatten_impl(SEXP);
 extern SEXP map_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP map2_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
@@ -19,7 +19,7 @@ extern SEXP vflatten_impl(SEXP, SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
   {"coerce_impl",           (DL_FUNC) &coerce_impl,    2},
-  {"pluck_impl",            (DL_FUNC) &pluck_impl,     5},
+  {"pluck_impl",            (DL_FUNC) &pluck_impl,     4},
   {"flatten_impl",          (DL_FUNC) &flatten_impl,   1},
   {"map_impl",              (DL_FUNC) &map_impl,       6},
   {"map2_impl",             (DL_FUNC) &map2_impl,      6},


### PR DESCRIPTION
Noted on CRAN's LTO build https://www.stats.ox.ac.uk/pub/bdr/LTO/purrr.out

`pluck_impl()` doesn't actually use `error_call` at the C level. I think this was just a holdover from when we were experimenting with passing that argument through to C, but then decided on another way.

```
init.c:12:13: warning: type of ‘pluck_impl’ does not match original declaration [-Wlto-type-mismatch]
   12 | extern SEXP pluck_impl(SEXP, SEXP, SEXP, SEXP, SEXP);
      |             ^
pluck.c:203:6: note: type mismatch in parameter 5
  203 | SEXP pluck_impl(SEXP x, SEXP index, SEXP missing, SEXP strict_arg) {
      |      ^
pluck.c:203:6: note: type ‘void’ should match type ‘struct SEXPREC *’
pluck.c:203:6: note: ‘pluck_impl’ was previously declared here
```

Gabor said he has fixed the other cli `-Wstrict-prototypes` issue

