### PR TITLE
Add cleancall support to close progress bars on early exits

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # purrr (development version)
 
+* Fixed an issue where progress bars weren't being closed when user interrupts
+  or errors were encountered during a `map()` call (#1024).
+
 * Fixed an invalid C signature for `pluck()` (#1018).
 
 * Set `Biarch: true` to build purrr on 32-bit Windows on R < 4.2.0 (#1017).

--- a/R/cleancall.R
+++ b/R/cleancall.R
@@ -1,0 +1,3 @@
+call_with_cleanup <- function(ptr, ...) {
+  .Call(cleancall_call, pairlist(ptr, ...), parent.frame())
+}

--- a/R/map.R
+++ b/R/map.R
@@ -171,7 +171,7 @@ map_ <- function(.type,
   with_indexed_errors(
     i = i,
     error_call = .purrr_error_call,
-    .Call(map_impl, environment(), .type, .progress, n, names, i)
+    call_with_cleanup(map_impl, environment(), .type, .progress, n, names, i)
   )
 }
 

--- a/R/map2.R
+++ b/R/map2.R
@@ -78,7 +78,7 @@ map2_ <- function(.type,
   with_indexed_errors(
     i = i,
     error_call = .purrr_error_call,
-    .Call(map2_impl, environment(), .type, .progress, n, names, i)
+    call_with_cleanup(map2_impl, environment(), .type, .progress, n, names, i)
   )
 }
 

--- a/R/pmap.R
+++ b/R/pmap.R
@@ -127,7 +127,7 @@ pmap_ <- function(.type,
   with_indexed_errors(
     i = i,
     error_call = .purrr_error_call,
-    .Call(pmap_impl, environment(), .type, .progress, n, names, i, call_names, call_n)
+    call_with_cleanup(pmap_impl, environment(), .type, .progress, n, names, i, call_names, call_n)
   )
 }
 

--- a/src/cleancall.c
+++ b/src/cleancall.c
@@ -1,0 +1,170 @@
+#define R_NO_REMAP
+#include <Rinternals.h>
+
+#include "cleancall.h"
+
+
+#if (defined(R_VERSION) && R_VERSION < R_Version(3, 4, 0))
+ SEXP R_MakeExternalPtrFn(DL_FUNC p, SEXP tag, SEXP prot) {
+   fn_ptr ptr;
+   ptr.fn = p;
+   return R_MakeExternalPtr(ptr.p, tag, prot);
+ }
+ DL_FUNC R_ExternalPtrAddrFn(SEXP s) {
+   fn_ptr ptr;
+   ptr.p = R_ExternalPtrAddr(s);
+   return ptr.fn;
+ }
+#endif
+
+// The R API does not have a setter for function pointers
+
+SEXP cleancall_MakeExternalPtrFn(DL_FUNC p, SEXP tag, SEXP prot) {
+    fn_ptr tmp;
+    tmp.fn = p;
+    return R_MakeExternalPtr(tmp.p, tag, prot);
+}
+
+void cleancall_SetExternalPtrAddrFn(SEXP s, DL_FUNC p) {
+    fn_ptr ptr;
+    ptr.fn = p;
+    R_SetExternalPtrAddr(s, ptr.p);
+}
+
+
+// Initialised at load time with the `.Call` primitive
+SEXP cleancall_fns_dot_call = NULL;
+
+void cleancall_init(void) {
+  cleancall_fns_dot_call = Rf_findVar(Rf_install(".Call"), R_BaseEnv);
+}
+
+struct eval_args {
+  SEXP call;
+  SEXP env;
+};
+
+static SEXP eval_wrap(void* data) {
+  struct eval_args* args = (struct eval_args*) data;
+  return Rf_eval(args->call, args->env);
+}
+
+
+SEXP cleancall_call(SEXP args, SEXP env) {
+  SEXP call = PROTECT(Rf_lcons(cleancall_fns_dot_call, args));
+  struct eval_args data = { call, env };
+
+  SEXP out = r_with_cleanup_context(&eval_wrap, &data);
+
+  UNPROTECT(1);
+  return out;
+}
+
+
+static SEXP callbacks = NULL;
+
+// Preallocate a callback
+static void push_callback(SEXP stack) {
+  SEXP top = CDR(stack);
+
+  SEXP early_handler = PROTECT(Rf_allocVector(LGLSXP, 1));
+  SEXP fn_extptr = PROTECT(cleancall_MakeExternalPtrFn(NULL, R_NilValue,
+                                                       R_NilValue));
+  SEXP data_extptr = PROTECT(R_MakeExternalPtr(NULL, early_handler,
+                                               R_NilValue));
+  SEXP cb = Rf_cons(Rf_cons(fn_extptr, data_extptr), top);
+
+  SETCDR(stack, cb);
+
+  UNPROTECT(3);
+}
+
+struct data_wrapper {
+  SEXP (*fn)(void* data);
+  void *data;
+  SEXP callbacks;
+  int success;
+};
+
+static void call_exits(void* data) {
+  // Remove protecting node. Don't remove the preallocated callback on
+  // the top as it might contain a handler when something went wrong.
+  SEXP top = CDR(callbacks);
+
+  // Restore old stack
+  struct data_wrapper* state = data;
+  callbacks = (SEXP) state->callbacks;
+
+  // Handlers should not jump
+  while (top != R_NilValue) {
+    SEXP cb = CAR(top);
+    top = CDR(top);
+
+    void (*fn)(void*) = (void (*)(void*)) R_ExternalPtrAddrFn(CAR(cb));
+    void *data = (void*) R_ExternalPtrAddr(CDR(cb));
+    int early_handler = LOGICAL(R_ExternalPtrTag(CDR(cb)))[0];
+
+    // Check for empty pointer in preallocated callbacks
+    if (fn) {
+      if (!early_handler || !state->success) fn(data);
+    }
+  }
+}
+
+static SEXP with_cleanup_context_wrap(void *data) {
+  struct data_wrapper* cdata = data;
+  SEXP ret = cdata->fn(cdata->data);
+  cdata->success = 1;
+  return ret;
+}
+
+SEXP r_with_cleanup_context(SEXP (*fn)(void* data), void* data) {
+  // Preallocate new stack before changing `callbacks` to avoid
+  // leaving the global variable in a bad state if alloc fails
+  SEXP new = PROTECT(Rf_cons(R_NilValue, R_NilValue));
+  push_callback(new);
+
+  if (!callbacks) callbacks = R_NilValue;
+
+  SEXP old = callbacks;
+  callbacks = new;
+
+  struct data_wrapper state = { fn, data, old, 0 };
+
+  SEXP out = R_ExecWithCleanup(with_cleanup_context_wrap, &state,
+                               &call_exits, &state);
+
+  UNPROTECT(1);
+  return out;
+}
+
+int r_cleancall_is_active(void) {
+  return callbacks != NULL;
+}
+
+static void call_save_handler(void (*fn)(void *data), void* data,
+                              int early) {
+  if (!callbacks) {
+    fn(data);
+    Rf_error("Internal error: Exit handler pushed outside "
+             "of an exit context");
+  }
+
+  SEXP cb = CADR(callbacks);
+
+  // Update pointers
+  cleancall_SetExternalPtrAddrFn(CAR(cb), (DL_FUNC) fn);
+  R_SetExternalPtrAddr(CDR(cb), data);
+  LOGICAL(R_ExternalPtrTag(CDR(cb)))[0] = early;
+
+  // Preallocate the next callback in case the allocator jumps
+  push_callback(callbacks);
+}
+
+void r_call_on_exit(void (*fn)(void* data), void* data) {
+  call_save_handler(fn, data, /* early = */ 0);
+}
+
+void r_call_on_early_exit(void (*fn)(void* data), void* data) {
+  call_save_handler(fn, data, /* early = */ 1);
+}

--- a/src/cleancall.h
+++ b/src/cleancall.h
@@ -1,0 +1,44 @@
+#ifndef CLEANCALL_H
+#define CLEANCALL_H
+
+#include <Rversion.h>
+#include <R_ext/Rdynload.h>
+
+// --------------------------------------------------------------------
+// Internals
+// --------------------------------------------------------------------
+
+typedef union {void* p; DL_FUNC fn;} fn_ptr;
+
+#if (defined(R_VERSION) && R_VERSION < R_Version(3, 4, 0))
+ SEXP R_MakeExternalPtrFn(DL_FUNC p, SEXP tag, SEXP prot);
+ DL_FUNC R_ExternalPtrAddrFn(SEXP s);
+#endif
+
+// --------------------------------------------------------------------
+// API for packages that embed cleancall
+// --------------------------------------------------------------------
+
+// The R API does not have a setter for external function pointers
+SEXP cleancall_MakeExternalPtrFn(DL_FUNC p, SEXP tag, SEXP prot);
+void cleancall_SetExternalPtrAddrFn(SEXP s, DL_FUNC p);
+
+#define CLEANCALL_METHOD_RECORD  \
+  {"cleancall_call", (DL_FUNC) &cleancall_call, 2}
+
+SEXP cleancall_call(SEXP args, SEXP env);
+extern SEXP cleancall_fns_dot_call;
+void cleancall_init(void);
+
+// --------------------------------------------------------------------
+// Public API
+// --------------------------------------------------------------------
+
+#define R_CLEANCALL_SUPPORT 1
+
+SEXP r_with_cleanup_context(SEXP (*fn)(void* data), void* data);
+void r_call_on_exit(void (*fn)(void* data), void* data);
+void r_call_on_early_exit(void (*fn)(void* data), void* data);
+int  r_cleancall_is_active(void);
+
+#endif

--- a/src/cleancall.h
+++ b/src/cleancall.h
@@ -2,7 +2,12 @@
 #define CLEANCALL_H
 
 #include <Rversion.h>
+#include <Rinternals.h>
 #include <R_ext/Rdynload.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 // --------------------------------------------------------------------
 // Internals
@@ -27,7 +32,6 @@ void cleancall_SetExternalPtrAddrFn(SEXP s, DL_FUNC p);
   {"cleancall_call", (DL_FUNC) &cleancall_call, 2}
 
 SEXP cleancall_call(SEXP args, SEXP env);
-extern SEXP cleancall_fns_dot_call;
 void cleancall_init(void);
 
 // --------------------------------------------------------------------
@@ -39,6 +43,9 @@ void cleancall_init(void);
 SEXP r_with_cleanup_context(SEXP (*fn)(void* data), void* data);
 void r_call_on_exit(void (*fn)(void* data), void* data);
 void r_call_on_early_exit(void (*fn)(void* data), void* data);
-int  r_cleancall_is_active(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/init.c
+++ b/src/init.c
@@ -7,6 +7,8 @@
 #include <R_ext/Visibility.h>
 #define export attribute_visible extern
 
+#include "cleancall.h"
+
 /* .Call calls */
 extern SEXP coerce_impl(SEXP, SEXP);
 extern SEXP pluck_impl(SEXP, SEXP, SEXP, SEXP);
@@ -18,6 +20,7 @@ extern SEXP transpose_impl(SEXP, SEXP);
 extern SEXP vflatten_impl(SEXP, SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
+  CLEANCALL_METHOD_RECORD,
   {"coerce_impl",           (DL_FUNC) &coerce_impl,    2},
   {"pluck_impl",            (DL_FUNC) &pluck_impl,     4},
   {"flatten_impl",          (DL_FUNC) &flatten_impl,   1},
@@ -34,4 +37,5 @@ export void R_init_purrr(DllInfo *dll)
 {
     R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
     R_useDynamicSymbols(dll, FALSE);
+    cleancall_init();
 }

--- a/src/map.c
+++ b/src/map.c
@@ -2,6 +2,7 @@
 #include <R.h>
 #include <Rversion.h>
 #include <Rinternals.h>
+#include "cleancall.h"
 #include "coerce.h"
 #include "conditions.h"
 #include "utils.h"


### PR DESCRIPTION
Closes #1024 

Fairly certain this is correct. It does seem to fix the problem from #1024, both with hitting `Esc` and my `stop()` example.

Had to use the `cleancall.c/h` from {cli} to get access to `R_CLEANCALL_SUPPORT` because I think `r-lib/cleancall` is a little out of date.

Otherwise, the instructions at https://github.com/r-lib/cleancall#embedding-cleancall worked well.

As @gaborcsardi mentioned here https://github.com/tidyverse/purrr/issues/1024#issuecomment-1363028007, this doesn't require any changes to the purrr code itself as long as we include `cleancall.h` before `cli/progress.h`, because `cli/progress.h` knows how to set `cli_progress_bar()` up with an early exit handler using cleancall if it detects that the cleancall header is included.
https://github.com/r-lib/cli/blob/bc503509cddb65d0007aeb301936e27de76bc7d7/inst/include/cli/progress.h#L298-L301