### PR TITLE
Install tidyr when build the pkgdown website

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,9 @@ LinkingTo:
 VignetteBuilder: 
     knitr
 Biarch: true
-Config/Needs/website: tidyverse/tidytemplate
+Config/Needs/website:
+    tidyverse/tidytemplate,
+    tidyr
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
It would be nice if the auto link worked.
![image](https://user-images.githubusercontent.com/50911393/214888600-e6c52cc1-7435-4220-8750-74637c17d74c.png)
