### PR TITLE
Remove duplicate listing of version 1.0.0 from pkgdown site

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -24,8 +24,6 @@ news:
     href: https://www.tidyverse.org/articles/2019/02/purrr-0-3-0/
   - text: "Version 0.2.3"
     href: https://www.tidyverse.org/articles/2017/08/purrr-0.2.3/
-  - text: "Version 1.0.0"
-    href: https://www.tidyverse.org/blog/2022/12/purrr-1-0-0/
 
 reference:
 - title: Map family


### PR DESCRIPTION
The purrr pkgdown site's News section lists the version 1.0.0 release twice. This commit removes the duplicate listing.