### PR TITLE
Use minimal defer() instead of local_bindings()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,11 +15,11 @@ BugReports: https://github.com/tidyverse/purrr/issues
 Depends: 
     R (>= 3.5.0)
 Imports:
-    cli (>= 3.4.0),
+    cli (>= 3.6.1),
     lifecycle (>= 1.0.3),
     magrittr (>= 1.5.0),
-    rlang (>= 0.4.10),
-    vctrs (>= 0.5.0)
+    rlang (>= 1.1.1),
+    vctrs (>= 0.6.3)
 Suggests: 
     covr,
     dplyr (>= 0.7.8),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # purrr (development version)
 
+* Deprecation infrastructure in `map_chr()` now has much less overhead 
+  leading to improved performance (#1089).
+
 * purrr now requires R 3.5.0.
 
 # purrr 1.0.1

--- a/R/coerce.R
+++ b/R/coerce.R
@@ -23,10 +23,18 @@ deprecate_to_char <- function(type) {
   )
 }
 
+
+# Can rewrite after https://github.com/r-lib/rlang/issues/1643
 local_deprecation_user_env <- function(user_env = caller_env(2), frame = caller_env()) {
-  local_bindings(
-    deprecation_user_env = user_env,
-    .env = the,
-    .frame = frame
-  )
+
+  old <- the$deprecation_user_env
+  the$deprecation_user_env <- user_env
+  defer(the$deprecation_user_env <- old, frame)
 }
+
+# Lightweight equivalent of withr::defer()
+defer <- function(expr, env = caller_env(), after = FALSE) {
+  thunk <- as.call(list(function() expr))
+  do.call(on.exit, list(thunk, TRUE, after), envir = env)
+}
+


### PR DESCRIPTION
Fixes #1089

This seems to eliminate most of the performance problem:

``` r
library(purrr)
x <- as.list(letters)

bench::mark(
  map_chr = map_chr(x, function(x) paste0(x, "a")),
  map = map(x, function(x) paste0(x, "a")) |> list_c(ptype = character()),
  map_vec = map_vec(x, function(x) paste0(x, "a"), .ptype = character())
)
#> # A tibble: 3 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 map_chr      39.6µs   41.4µs    23769.    3.88MB     35.7
#> 2 map            46µs   47.7µs    20567.   51.27KB     36.2
#> 3 map_vec      52.2µs   53.9µs    18327.      71KB     35.9
```

<sup>Created on 2023-07-27 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>