### PR TITLE
fix: `list_transpose()` takes into account all elements for the template

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # purrr (development version)
 
+* `list_transpose()` inspects all elements to determine the correct
+  template if it's not provided by the user  (#1128, @krlmlr).
+
 # purrr 1.0.2
 
 * Fixed valgrind issue.

--- a/R/list-transpose.R
+++ b/R/list-transpose.R
@@ -74,8 +74,12 @@ list_transpose <- function(x,
 
   if (length(x) == 0) {
     template <- integer()
-  } else {
-    template <- template %||% reduce(map(x, vec_index), vec_set_union)
+  } else if (is.null(template)) {
+    template <- reduce(
+      map(x, vec_index),
+      vec_set_union,
+      error_call = caller_env()
+    )
   }
 
   if (!is.character(template) && !is.numeric(template)) {

--- a/R/list-transpose.R
+++ b/R/list-transpose.R
@@ -14,9 +14,9 @@
 #' @param x A list of vectors to transpose.
 #' @param template A "template" that describes the output list. Can either be
 #'   a character vector (where elements are extracted by name), or an integer
-#'   vector (where elements are extracted by position). Defaults to the names
-#'   of the first element of `x`, or if they're not present, the integer
-#'   indices.
+#'   vector (where elements are extracted by position). Defaults to the union
+#'   of the names of the elements of `x`, or if they're not present, the
+#'   union of the integer indices.
 #' @param simplify Should the result be [simplified][list_simplify]?
 #'   * `TRUE`: simplify or die trying.
 #'   * `NA`: simplify if possible.
@@ -75,7 +75,7 @@ list_transpose <- function(x,
   if (length(x) == 0) {
     template <- integer()
   } else {
-    template <- template %||% vec_index(x[[1]])
+    template <- template %||% reduce(map(x, vec_index), vec_set_union)
   }
 
   if (!is.character(template) && !is.numeric(template)) {

--- a/R/list-transpose.R
+++ b/R/list-transpose.R
@@ -75,10 +75,15 @@ list_transpose <- function(x,
   if (length(x) == 0) {
     template <- integer()
   } else if (is.null(template)) {
-    template <- reduce(
-      map(x, vec_index),
-      vec_set_union,
-      error_call = caller_env()
+    indexes <- map(x, vec_index)
+    try_fetch(
+      template <- reduce(indexes, vec_set_union),
+      vctrs_error_ptype2 = function(e) {
+        cli::cli_abort(
+          "Can't combine named and unnamed vectors.",
+          arg = template
+        )
+      }
     )
   }
 

--- a/R/list-transpose.R
+++ b/R/list-transpose.R
@@ -76,12 +76,14 @@ list_transpose <- function(x,
     template <- integer()
   } else if (is.null(template)) {
     indexes <- map(x, vec_index)
-    try_fetch(
+    call <- current_env()
+    withCallingHandlers(
       template <- reduce(indexes, vec_set_union),
       vctrs_error_ptype2 = function(e) {
         cli::cli_abort(
           "Can't combine named and unnamed vectors.",
-          arg = template
+          arg = template,
+          call = call
         )
       }
     )

--- a/man/list_transpose.Rd
+++ b/man/list_transpose.Rd
@@ -20,9 +20,9 @@ list_transpose(
 
 \item{template}{A "template" that describes the output list. Can either be
 a character vector (where elements are extracted by name), or an integer
-vector (where elements are extracted by position). Defaults to the names
-of the first element of \code{x}, or if they're not present, the integer
-indices.}
+vector (where elements are extracted by position). Defaults to the union
+of the names of the elements of \code{x}, or if they're not present, the
+union of the integer indices.}
 
 \item{simplify}{Should the result be \link[=list_simplify]{simplified}?
 \itemize{

--- a/tests/testthat/_snaps/list-transpose.md
+++ b/tests/testthat/_snaps/list-transpose.md
@@ -69,6 +69,6 @@
     Code
       list_transpose(list(x = list(a = 1, b = 2), y = list(3, 4)))
     Condition
-      Error in `fn()`:
+      Error:
       ! Can't combine `x` <character> and `y` <integer>.
 

--- a/tests/testthat/_snaps/list-transpose.md
+++ b/tests/testthat/_snaps/list-transpose.md
@@ -67,8 +67,8 @@
 # fail mixing named and unnamed vectors
 
     Code
-      list_transpose(list(x = list(a = 1, b = 2), y = list(3, 4)))
+      test_list_transpose()
     Condition
-      Error in `handlers[[1L]]()`:
+      Error in `list_transpose()`:
       ! Can't combine named and unnamed vectors.
 

--- a/tests/testthat/_snaps/list-transpose.md
+++ b/tests/testthat/_snaps/list-transpose.md
@@ -64,3 +64,11 @@
       Error in `list_transpose()`:
       ! `template` must be a character or numeric vector, not a function.
 
+# fail mixing named and unnamed vectors
+
+    Code
+      list_transpose(list(x = list(a = 1, b = 2), y = list(3, 4)))
+    Condition
+      Error in `fn()`:
+      ! Can't combine `x` <character> and `y` <integer>.
+

--- a/tests/testthat/_snaps/list-transpose.md
+++ b/tests/testthat/_snaps/list-transpose.md
@@ -69,6 +69,6 @@
     Code
       list_transpose(list(x = list(a = 1, b = 2), y = list(3, 4)))
     Condition
-      Error:
-      ! Can't combine `x` <character> and `y` <integer>.
+      Error in `handlers[[1L]]()`:
+      ! Can't combine named and unnamed vectors.
 

--- a/tests/testthat/test-list-transpose.R
+++ b/tests/testthat/test-list-transpose.R
@@ -132,8 +132,11 @@ test_that("validates inputs", {
 })
 
 test_that("fail mixing named and unnamed vectors", {
-  x <- list(list(a = 1, b = 2), list(a = 3, b = 4))
-  expect_snapshot(error = TRUE, {
+  test_list_transpose <- function() {
+    x <- list(list(a = 1, b = 2), list(a = 3, b = 4))
     list_transpose(list(x = list(a = 1, b = 2), y = list(3, 4)))
+  }
+  expect_snapshot(error = TRUE, {
+    test_list_transpose()
   })
 })

--- a/tests/testthat/test-list-transpose.R
+++ b/tests/testthat/test-list-transpose.R
@@ -13,7 +13,7 @@ test_that("can use character template", {
   # Default:
   expect_equal(
     list_transpose(x, default = NA),
-    list(a = c(1, NA), b = c(2, 3))
+    list(a = c(1, NA), b = c(2, 3), c = c(NA, 4))
   )
 
   # Change order
@@ -128,5 +128,12 @@ test_that("validates inputs", {
   expect_snapshot(error = TRUE, {
     list_transpose(10)
     list_transpose(list(1), template = mean)
+  })
+})
+
+test_that("fail mixing named and unnamed vectors", {
+  x <- list(list(a = 1, b = 2), list(a = 3, b = 4))
+  expect_snapshot(error = TRUE, {
+    list_transpose(list(x = list(a = 1, b = 2), y = list(3, 4)))
   })
 })


### PR DESCRIPTION
This introduces an error for the case when mixing named and unnamed elements, it was a silent error before.

Closes #1128.