### PR TITLE
Move `reduce_right()` notes

### DIFF
--- a/R/reduce.R
+++ b/R/reduce.R
@@ -508,7 +508,7 @@ accumulate_names <- function(nms, init, dir) {
 #' reduce(rev(1:3), f)
 #' ```
 #'
-#' `reduce2_right()` is soft-deprecated as of purrr 0.3.0 without
+#' `reduce2_right()` is deprecated as of purrr 0.3.0 without
 #' replacement. It is not clear what algorithmic properties should a
 #' right reduction have in this case. Please reach out if you know
 #' about a use case for a right reduction with a ternary function.

--- a/R/reduce.R
+++ b/R/reduce.R
@@ -43,30 +43,6 @@
 #' the left produces a left-leaning nested list (or tree), while
 #' reducing `list()` from the right produces a right-leaning list.
 #'
-#' @section Life cycle:
-#'
-#' `reduce_right()` is soft-deprecated as of purrr 0.3.0. Please use
-#' the `.dir` argument of `reduce()` instead. Note that the algorithm
-#' has changed. Whereas `reduce_right()` computed `f(f(3, 2), 1)`,
-#' `reduce(.dir = \"backward\")` computes `f(1, f(2, 3))`. This is the
-#' standard way of reducing from the right.
-#'
-#' To update your code with the same reduction as `reduce_right()`,
-#' simply reverse your vector and use a left reduction:
-#'
-#' ```{r, eval = FALSE}
-#' # Before:
-#' reduce_right(1:3, f)
-#'
-#' # After:
-#' reduce(rev(1:3), f)
-#' ```
-#'
-#' `reduce2_right()` is soft-deprecated as of purrr 0.3.0 without
-#' replacement. It is not clear what algorithmic properties should a
-#' right reduction have in this case. Please reach out if you know
-#' about a use case for a right reduction with a ternary function.
-#'
 #' @seealso [accumulate()] for a version that returns all intermediate
 #'   values of the reduction.
 #' @examples
@@ -515,12 +491,29 @@ accumulate_names <- function(nms, init, dir) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' These functions were deprecated in purrr 0.3.0. Please use the
-#' `.dir` argument of [reduce()] instead, or reverse your vectors
-#' and use a left reduction.
+#' `reduce_right()` is soft-deprecated as of purrr 0.3.0. Please use
+#' the `.dir` argument of `reduce()` instead. Note that the algorithm
+#' has changed. Whereas `reduce_right()` computed `f(f(3, 2), 1)`,
+#' `reduce(.dir = \"backward\")` computes `f(1, f(2, 3))`. This is the
+#' standard way of reducing from the right.
+#'
+#' To update your code with the same reduction as `reduce_right()`,
+#' simply reverse your vector and use a left reduction:
+#'
+#' ```R
+#' # Before:
+#' reduce_right(1:3, f)
+#'
+#' # After:
+#' reduce(rev(1:3), f)
+#' ```
+#'
+#' `reduce2_right()` is soft-deprecated as of purrr 0.3.0 without
+#' replacement. It is not clear what algorithmic properties should a
+#' right reduction have in this case. Please reach out if you know
+#' about a use case for a right reduction with a ternary function.
 #'
 #' @inheritParams reduce
-#'
 #' @keywords internal
 #' @export
 reduce_right <- function(.x, .f, ..., .init) {

--- a/man/reduce.Rd
+++ b/man/reduce.Rd
@@ -70,31 +70,6 @@ the left produces a left-leaning nested list (or tree), while
 reducing \code{list()} from the right produces a right-leaning list.
 }
 
-\section{Life cycle}{
-
-
-\code{reduce_right()} is soft-deprecated as of purrr 0.3.0. Please use
-the \code{.dir} argument of \code{reduce()} instead. Note that the algorithm
-has changed. Whereas \code{reduce_right()} computed \code{f(f(3, 2), 1)},
-\verb{reduce(.dir = \\"backward\\")} computes \code{f(1, f(2, 3))}. This is the
-standard way of reducing from the right.
-
-To update your code with the same reduction as \code{reduce_right()},
-simply reverse your vector and use a left reduction:
-
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{# Before:
-reduce_right(1:3, f)
-
-# After:
-reduce(rev(1:3), f)
-}\if{html}{\out{</div>}}
-
-\code{reduce2_right()} is soft-deprecated as of purrr 0.3.0 without
-replacement. It is not clear what algorithmic properties should a
-right reduction have in this case. Please reach out if you know
-about a use case for a right reduction with a ternary function.
-}
-
 \examples{
 # Reducing `+` computes the sum of a vector while reducing `*`
 # computes the product:

--- a/man/reduce_right.Rd
+++ b/man/reduce_right.Rd
@@ -52,8 +52,25 @@ should be 1 element shorter than \code{.x}.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-These functions were deprecated in purrr 0.3.0. Please use the
-\code{.dir} argument of \code{\link[=reduce]{reduce()}} instead, or reverse your vectors
-and use a left reduction.
+\code{reduce_right()} is soft-deprecated as of purrr 0.3.0. Please use
+the \code{.dir} argument of \code{reduce()} instead. Note that the algorithm
+has changed. Whereas \code{reduce_right()} computed \code{f(f(3, 2), 1)},
+\verb{reduce(.dir = \\"backward\\")} computes \code{f(1, f(2, 3))}. This is the
+standard way of reducing from the right.
+
+To update your code with the same reduction as \code{reduce_right()},
+simply reverse your vector and use a left reduction:
+
+\if{html}{\out{<div class="sourceCode R">}}\preformatted{# Before:
+reduce_right(1:3, f)
+
+# After:
+reduce(rev(1:3), f)
+}\if{html}{\out{</div>}}
+
+\code{reduce2_right()} is soft-deprecated as of purrr 0.3.0 without
+replacement. It is not clear what algorithmic properties should a
+right reduction have in this case. Please reach out if you know
+about a use case for a right reduction with a ternary function.
 }
 \keyword{internal}

--- a/man/reduce_right.Rd
+++ b/man/reduce_right.Rd
@@ -68,7 +68,7 @@ reduce_right(1:3, f)
 reduce(rev(1:3), f)
 }\if{html}{\out{</div>}}
 
-\code{reduce2_right()} is soft-deprecated as of purrr 0.3.0 without
+\code{reduce2_right()} is deprecated as of purrr 0.3.0 without
 replacement. It is not clear what algorithmic properties should a
 right reduction have in this case. Please reach out if you know
 about a use case for a right reduction with a ternary function.


### PR DESCRIPTION
I think it makes more sense to put them in the `reduce_right()` docs, rather than the `reduce()` docs.