### PR TITLE
Revert allowing data frames in `list_transpose()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # purrr (development version)
 
-* `list_transpose()` now works with data.frames (@KimLopezGuell, #1109).
+* Added a test to assert that `list_transpose()` does not work on data frames
+  (@KimLopezGuell, #1141, #1149).
 * Added `imap_vec()` (#1084)
 * `list_transpose()` inspects all elements to determine the correct
   template if it's not provided by the user  (#1128, @krlmlr).

--- a/R/list-transpose.R
+++ b/R/list-transpose.R
@@ -69,8 +69,7 @@ list_transpose <- function(x,
                            simplify = NA,
                            ptype = NULL,
                            default = NULL) {
-
-  check_list(x)
+  obj_check_list(x)
   check_dots_empty()
 
   if (length(x) == 0) {

--- a/tests/testthat/_snaps/list-transpose.md
+++ b/tests/testthat/_snaps/list-transpose.md
@@ -1,3 +1,11 @@
+# can't transpose data frames
+
+    Code
+      list_transpose(df)
+    Condition
+      Error in `list_transpose()`:
+      ! `x` must be a list, not a <data.frame> object.
+
 # integer template requires exact length of list() simplify etc
 
     Code
@@ -57,7 +65,7 @@
       list_transpose(10)
     Condition
       Error in `list_transpose()`:
-      ! `x` must be a list, not a number.
+      ! `x` must be a list, not the number 10.
     Code
       list_transpose(list(1), template = mean)
     Condition

--- a/tests/testthat/test-list-transpose.R
+++ b/tests/testthat/test-list-transpose.R
@@ -8,9 +8,7 @@ test_that("can't transpose data frames", {
   df <- data.frame(x = 1:2, y = 4:5)
 
   # i.e. be consistent with other `list_*()` functions from purrr/vctrs
-  expect_snapshot(error = TRUE, {
-    list_transpose(df)
-  })
+  expect_snapshot(error = TRUE, list_transpose(df))
 })
 
 test_that("transposing empty list returns empty list", {

--- a/tests/testthat/test-list-transpose.R
+++ b/tests/testthat/test-list-transpose.R
@@ -4,10 +4,13 @@ test_that("can transpose homogenous list", {
   expect_equal(out, list(a = c(x = 1, y = 3), b = c(x = 2, y = 4)))
 })
 
-test_that("can transpose data frames", {
+test_that("can't transpose data frames", {
   df <- data.frame(x = 1:2, y = 4:5)
-  out <- list_transpose(df)
-  expect_equal(out, list(c(x = 1, y = 4), c(x = 2, y = 5)))
+
+  # i.e. be consistent with other `list_*()` functions from purrr/vctrs
+  expect_snapshot(error = TRUE, {
+    list_transpose(df)
+  })
 })
 
 test_that("transposing empty list returns empty list", {


### PR DESCRIPTION
Reverts #1141

@KimLopezGuell we have looked at this a bit more in detail and decided that we actually should not have labeled this an issue for TDD, that is totally our fault! We do actually want to be strict about `list_transpose()` only allowing lists, not data frames, just like almost every other `list_*()` function in both purrr and vctrs. But your PR was great, and we hope you had a lot of fun at TDD! I've reused your test as an additional check for this going forward, so not all was lost!
