### PR TITLE
Fix CRAN ASAN error

### DIFF
--- a/.github/workflows/rhub.yaml
+++ b/.github/workflows/rhub.yaml
@@ -1,13 +1,13 @@
-# R-hub's genetic GitHub Actions workflow file. It's canonical location is at
-# https://github.com/r-hub/rhub2/blob/v1/inst/workflow/rhub.yaml
+# R-hub's generic GitHub Actions workflow file. It's canonical location is at
+# https://github.com/r-hub/actions/blob/v1/workflows/rhub.yaml
 # You can update this file to a newer version using the rhub2 package:
 #
-# rhub2::rhub_setup()
+# rhub::rhub_setup()
 #
 # It is unlikely that you need to modify this file manually.
 
 name: R-hub
-run-name: ${{ github.event.inputs.name || format('Manually run by {0}', github.triggering_actor) }} (${{ github.event.inputs.id }})
+run-name: "${{ github.event.inputs.id }}: ${{ github.event.inputs.name || format('Manually run by {0}', github.triggering_actor) }}"
 
 on:
   workflow_dispatch:
@@ -33,7 +33,7 @@ jobs:
 
     steps:
     # NO NEED TO CHECKOUT HERE
-    - uses: r-hub/rhub2/actions/rhub-setup@v1
+    - uses: r-hub/actions/setup@v1
       with:
         config: ${{ github.event.inputs.config }}
       id: rhub-setup
@@ -51,8 +51,16 @@ jobs:
       image: ${{ matrix.config.container }}
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: r-hub/rhub2/actions/rhub-check@v1
+      - uses: r-hub/actions/checkout@v1
+      - uses: r-hub/actions/platform-info@v1
+        with:
+          token: ${{ secrets.RHUB_TOKEN }}
+          job-config: ${{ matrix.config.job-config }}
+      - uses: r-hub/actions/setup-deps@v1
+        with:
+          token: ${{ secrets.RHUB_TOKEN }}
+          job-config: ${{ matrix.config.job-config }}
+      - uses: r-hub/actions/run-check@v1
         with:
           token: ${{ secrets.RHUB_TOKEN }}
           job-config: ${{ matrix.config.job-config }}
@@ -68,12 +76,20 @@ jobs:
         config: ${{ fromJson(needs.setup.outputs.platforms) }}
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: r-hub/rhub2/actions/rhub-setup-r@v1
+      - uses: r-hub/actions/checkout@v1
+      - uses: r-hub/actions/setup-r@v1
         with:
           job-config: ${{ matrix.config.job-config }}
           token: ${{ secrets.RHUB_TOKEN }}
-      - uses: r-hub/rhub2/actions/rhub-check@v1
+      - uses: r-hub/actions/platform-info@v1
+        with:
+          token: ${{ secrets.RHUB_TOKEN }}
+          job-config: ${{ matrix.config.job-config }}
+      - uses: r-hub/actions/setup-deps@v1
+        with:
+          job-config: ${{ matrix.config.job-config }}
+          token: ${{ secrets.RHUB_TOKEN }}
+      - uses: r-hub/actions/run-check@v1
         with:
           job-config: ${{ matrix.config.job-config }}
           token: ${{ secrets.RHUB_TOKEN }}

--- a/src/map.c
+++ b/src/map.c
@@ -12,7 +12,7 @@
 #include "cleancall.h"
 
 static
-void cb_progress_done(void* bar) {
+void cb_progress_done(void* bar_ptr) {
   SEXP bar = (SEXP)bar_ptr;
   cli_progress_done(bar);
   R_ReleaseObject(bar);

--- a/src/map.c
+++ b/src/map.c
@@ -12,7 +12,8 @@
 #include "cleancall.h"
 
 static
-void cb_progress_done(SEXP bar) {
+void cb_progress_done(void* bar) {
+  SEXP bar = (SEXP)bar_ptr;
   cli_progress_done(bar);
   R_ReleaseObject(bar);
 }


### PR DESCRIPTION
Fixes #1157

I confirmed that clang-asan fails on current purrr with a similar error to what we're seeing in valr. This is in purrr-Ex.Rout from [this rhub check](https://github.com/jayhesselberth/purrr/actions/runs/12720310041/job/35461775454).

```
cleancall.c:110:46: runtime error: call to function cb_progress_done through pointer to incorrect function type 'void (*)(void *)'
/__w/purrr/purrr/check/purrr.Rcheck/00_pkg_src/purrr/src/map.c:15: note: cb_progress_done defined here
    #0 0x7fd287f0d48b in call_exits /__w/purrr/purrr/check/purrr.Rcheck/00_pkg_src/purrr/src/cleancall.c:110:46
    #1 0x7fd28ddf1131 in R_ExecWithCleanup /tmp/R-devel/src/main/context.c:913:5
    #2 0x7fd287f0cdf2 in r_with_cleanup_context /__w/purrr/purrr/check/purrr.Rcheck/00_pkg_src/purrr/src/cleancall.c:133:14
```

This simple patch proposed on the R-devel mailing list fixes that clang-asan error ([clang asan run](https://github.com/jayhesselberth/purrr/actions/runs/12718786947/job/35457848128)).

Also updated the rhub action because it was useful to debug this issue.