### PR TITLE
Move into compliance with C API changes

### DIFF
--- a/src/backports.c
+++ b/src/backports.c
@@ -8,3 +8,13 @@ SEXP Rf_installChar(SEXP x) {
   return Rf_install(CHAR(x));
 }
 #endif
+
+#if defined(R_VERSION) && R_VERSION < R_Version(4, 5, 0)
+SEXP R_mkClosure(SEXP formals, SEXP body, SEXP env) {
+  SEXP fun = Rf_allocSExp(CLOSXP);
+  SET_FORMALS(fun, formals);
+  SET_BODY(fun, body);
+  SET_CLOENV(fun, env);
+  return fun;
+}
+#endif

--- a/src/backports.h
+++ b/src/backports.h
@@ -4,7 +4,11 @@
 #include <Rversion.h>
 
 #if defined(R_VERSION) && R_VERSION < R_Version(3, 2, 0)
-SEXP Rf_installChar(SEXP x);
+SEXP Rf_installChar(SEXP);
+#endif
+
+#if defined(R_VERSION) && R_VERSION < R_Version(4, 5, 0)
+SEXP R_mkClosure(SEXP, SEXP, SEXP);
 #endif
 
 #endif

--- a/src/conditions.c
+++ b/src/conditions.c
@@ -1,5 +1,6 @@
 #define R_NO_REMAP
 #include <Rinternals.h>
+#include "backports.h"
 #include "utils.h"
 #include <R_ext/Parse.h>
 
@@ -19,10 +20,7 @@ SEXP current_env(void) {
     SEXP parsed = PROTECT(R_ParseVector(code, -1, &status, R_NilValue));
     SEXP body = VECTOR_ELT(parsed, 0);
 
-    SEXP fn = PROTECT(Rf_allocSExp(CLOSXP));
-    SET_FORMALS(fn, R_NilValue);
-    SET_BODY(fn, body);
-    SET_CLOENV(fn, R_BaseEnv);
+    SEXP fn = PROTECT(R_mkClosure(R_NilValue, body, R_BaseEnv));
 
     call = Rf_lang1(fn);
     R_PreserveObject(call);

--- a/src/map.c
+++ b/src/map.c
@@ -164,7 +164,7 @@ SEXP pmap_impl(SEXP env,
   PROTECT_WITH_INDEX(call, &call_shelter);
 
   bool has_call_names = call_names != R_NilValue;
-  const SEXP* v_call_names = has_call_names ? STRING_PTR(call_names) : NULL;
+  const SEXP* v_call_names = has_call_names ? STRING_PTR_RO(call_names) : NULL;
   int call_n = INTEGER_ELT(ffi_call_n, 0);
 
   for (int j = call_n - 1; j >= 0; --j) {

--- a/src/pluck.c
+++ b/src/pluck.c
@@ -152,7 +152,7 @@ SEXP extract_env(SEXP x, SEXP index_i, int i, bool strict) {
   }
 
   SEXP sym = Rf_installChar(index);
-  SEXP out = Rf_findVarInFrame3(x, sym, TRUE);
+  SEXP out = Rf_findVarInFrame(x, sym);
 
   if (check_unbound_value(out, index_i, strict)) {
     return R_NilValue;


### PR DESCRIPTION
`Rf_findVarInFrame3` -> `Rf_findVarInFrame`
`STRING_PTR` -> `STR_PTR_RO`
`SET_FORMALS`, `SET_BODY`, `SET_CLOENV` -> `R_mkClosure` (backported for R < 4.5.0)

Fixes #1164.