### PR TITLE
Use CRAN mirai

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Suggests:
     httr,
     knitr,
     lubridate,
-    mirai (>= 2.0.1.9005),
+    mirai (>= 2.1.0),
     rmarkdown,
     testthat (>= 3.0.0),
     tibble,
@@ -45,4 +45,3 @@ Config/testthat/parallel: TRUE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
-Remotes: shikokuchuo/mirai

--- a/R/parallelization.R
+++ b/R/parallelization.R
@@ -99,7 +99,7 @@
 #'
 #' # Further documentation
 #'
-#' \pkg{purrr}'s parallelization is powered by \CRANpkg{mirai}.See the
+#' \pkg{purrr}'s parallelization is powered by \CRANpkg{mirai}. See the
 #' [mirai introduction and reference](https://shikokuchuo.net/mirai/articles/mirai.html)
 #' for more details.
 #'

--- a/man/parallelization.Rd
+++ b/man/parallelization.Rd
@@ -102,7 +102,7 @@ For details on further options, see \link[carrier:crate]{carrier::crate}.
 }
 
 \section{Further documentation}{
-\pkg{purrr}'s parallelization is powered by \CRANpkg{mirai}.See the
+\pkg{purrr}'s parallelization is powered by \CRANpkg{mirai}. See the
 \href{https://shikokuchuo.net/mirai/articles/mirai.html}{mirai introduction and reference}
 for more details.
 


### PR DESCRIPTION
mirai 2.1.0 which fully supports the new purrr parallelization features is already on CRAN.

Will leave this as a draft until the binary builds propagate.