### PR TITLE
add .allow_na in keep and discard to prevent error with NAs in .x

### DIFF
--- a/R/keep.R
+++ b/R/keep.R
@@ -42,14 +42,16 @@
 #' list(a = "a", b = NULL, c = integer(0), d = NA, e = list()) |>
 #'   compact()
 keep <- function(.x, .p, ...) {
-  where <- where_if(.x, .p, ...)
+  .allow_na <- ifelse(anyNA(.x), TRUE, FALSE)
+  where <- where_if(.x, .p, .allow_na = .allow_na, ...)
   .x[!is.na(where) & where]
 }
 
 #' @export
 #' @rdname keep
 discard <- function(.x, .p, ...) {
-  where <- where_if(.x, .p, ...)
+  .allow_na <- ifelse(anyNA(.x), TRUE, FALSE)
+  where <- where_if(.x, .p, .allow_na = .allow_na, ...)
   .x[is.na(where) | !where]
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -44,12 +44,12 @@ where_at <- function(x,
   }
 }
 
-where_if <- function(.x, .p, ..., .purrr_error_call = caller_env()) {
+where_if <- function(.x, .p, ..., .allow_na = FALSE, .purrr_error_call = caller_env()) {
   if (is_logical(.p)) {
     stopifnot(length(.p) == length(.x))
     .p
   } else {
-    .p <- as_predicate(.p, ..., .mapper = TRUE, .purrr_error_call = NULL)
+    .p <- as_predicate(.p, ..., .mapper = TRUE, .allow_na = .allow_na, .purrr_error_call = NULL)
     map_(.x, .p, ..., .type = "logical", .purrr_error_call = .purrr_error_call)
   }
 }

--- a/tests/testthat/test-keep.R
+++ b/tests/testthat/test-keep.R
@@ -15,6 +15,11 @@ test_that("keep() and discard() require predicate functions", {
   })
 })
 
+test_that("keep() and discard() can run with NA in .x", {
+  expect_equal(keep(c(1, 2, NA, 3), ~ .x != 2), c(1, 3))
+  expect_equal(discard(c(1, 2, NA, 3), ~ .x != 2), c(2, NA))
+})
+
 # keep_at / discard_at ----------------------------------------------------
 
 test_that("can keep_at/discard_at with character vector", {


### PR DESCRIPTION
fixes #1156 

Not sure I've implemented the right solution. 

The error comes from the `as_predicate` function when NA is returned. The function can have `.allow_na=TRUE` to account for this. But that messes with some other logic when passed all the way through - this test was set up expecting an error:
`keep(1:3), ~NA`
I added an ifelse to keep that test passing, but it could still change behavior.

Alternatively, `.allow_na` could become an argument in `keep` , but I see it's not an exported argument anywhere else, so I was hesitant to put it in.