### PR TITLE
Updates post-mirai 2.3.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Suggests:
     httr,
     knitr,
     lubridate,
-    mirai (>= 2.1.0),
+    mirai (>= 2.3.0),
     rmarkdown,
     testthat (>= 3.0.0),
     tibble,

--- a/R/map.R
+++ b/R/map.R
@@ -211,7 +211,7 @@ map_ <- function(.type,
 
 mmap_ <- function(.x, .f, .progress, .type, error_call, ...) {
 
-  rlang::check_installed(c("mirai", "carrier"), reason = "for parallel map.")
+  check_installed(c("mirai", "carrier"), reason = "for parallel map.")
 
   if (!mirai::daemons_set()) {
     cli::cli_abort(
@@ -227,7 +227,7 @@ mmap_ <- function(.x, .f, .progress, .type, error_call, ...) {
   }
 
   if (!isNamespace(topenv(environment(.f))) && !carrier::is_crate(.f)) {
-    .f <- carrier::crate(rlang::set_env(.f))
+    .f <- carrier::crate(set_env(.f))
     cli::cli_inform(c(
       v = "Automatically crated `.f`: {format(lobstr::obj_size(.f))}"
     ))

--- a/R/map.R
+++ b/R/map.R
@@ -211,10 +211,7 @@ map_ <- function(.type,
 
 mmap_ <- function(.x, .f, .progress, .type, error_call, ...) {
 
-  if (is.null(the$packages_installed)) {
-    rlang::check_installed(c("mirai", "carrier"), reason = "for parallel map.")
-    the$packages_installed <- TRUE
-  }
+  rlang::check_installed(c("mirai", "carrier"), reason = "for parallel map.")
 
   if (!mirai::daemons_set()) {
     cli::cli_abort(

--- a/R/map.R
+++ b/R/map.R
@@ -211,7 +211,14 @@ map_ <- function(.type,
 
 mmap_ <- function(.x, .f, .progress, .type, error_call, ...) {
 
-  check_installed(c("mirai", "carrier"), reason = "for parallel map.")
+  if (is.null(the$packages_installed)) {
+    check_installed(
+      c("mirai", "carrier"),
+      version = c("2.3.0", "0.1.1"),
+      reason = "for parallel map."
+    )
+    the$packages_installed <- TRUE
+  }
 
   if (!mirai::daemons_set()) {
     cli::cli_abort(

--- a/R/map.R
+++ b/R/map.R
@@ -216,7 +216,7 @@ mmap_ <- function(.x, .f, .progress, .type, error_call, ...) {
     the$packages_installed <- TRUE
   }
 
-  if (is.null(mirai::nextget("n"))) {
+  if (!mirai::daemons_set()) {
     cli::cli_abort(
       "No daemons set - use e.g. {.run mirai::daemons(6)} to set 6 local daemons.",
       call = error_call

--- a/R/parallelization.R
+++ b/R/parallelization.R
@@ -15,10 +15,10 @@
 #'
 #' # Daemons settings
 #'
-#' How and where parallelization occurs is determined by
-#' [mirai::daemons()]. This is a function from the \pkg{mirai}
-#' package that sets up daemons (persistent background processes that receive
-#' parallel computations) on your local machine or across the network.
+#' How and where parallelization occurs is determined by [mirai::daemons()].
+#' This is a function from the \pkg{mirai} package that sets up daemons
+#' (persistent background processes that receive parallel computations) on your
+#' local machine or across the network.
 #'
 #' \pkg{purrr} requires these to be set up prior to performing any parallel map
 #' operations. It is usual to set daemons once per session. You can leave them
@@ -100,8 +100,7 @@
 #' # Further documentation
 #'
 #' \pkg{purrr}'s parallelization is powered by \CRANpkg{mirai}. See the
-#' [mirai introduction and reference](https://shikokuchuo.net/mirai/articles/mirai.html)
-#' for more details.
+#' [mirai website](https://mirai.r-lib.org/) for more details.
 #'
 #' Crating is provided by the \CRANpkg{carrier} package. See the
 #' [carrier readme](https://github.com/r-lib/carrier) for more details.

--- a/man/parallelization.Rd
+++ b/man/parallelization.Rd
@@ -17,10 +17,10 @@ according to your individual setup and task, but a rough guide would be in
 the order of 100 microseconds to 1 millisecond for each map iteration.
 }
 \section{Daemons settings}{
-How and where parallelization occurs is determined by
-\code{\link[mirai:daemons]{mirai::daemons()}}. This is a function from the \pkg{mirai}
-package that sets up daemons (persistent background processes that receive
-parallel computations) on your local machine or across the network.
+How and where parallelization occurs is determined by \code{\link[mirai:daemons]{mirai::daemons()}}.
+This is a function from the \pkg{mirai} package that sets up daemons
+(persistent background processes that receive parallel computations) on your
+local machine or across the network.
 
 \pkg{purrr} requires these to be set up prior to performing any parallel map
 operations. It is usual to set daemons once per session. You can leave them
@@ -103,8 +103,7 @@ For details on further options, see \link[carrier:crate]{carrier::crate}.
 
 \section{Further documentation}{
 \pkg{purrr}'s parallelization is powered by \CRANpkg{mirai}. See the
-\href{https://shikokuchuo.net/mirai/articles/mirai.html}{mirai introduction and reference}
-for more details.
+\href{https://mirai.r-lib.org/}{mirai website} for more details.
 
 Crating is provided by the \CRANpkg{carrier} package. See the
 \href{https://github.com/r-lib/carrier}{carrier readme} for more details.

--- a/man/purrr-package.Rd
+++ b/man/purrr-package.Rd
@@ -29,7 +29,7 @@ Authors:
 
 Other contributors:
 \itemize{
-  \item Posit Software, PBC [copyright holder, funder]
+  \item Posit Software, PBC (https://ror.org/03wc8by49) [copyright holder, funder]
 }
 
 }


### PR DESCRIPTION
Minor updates:
- Uses the new `mirai::daemons_set()`
- Updates mirai URLs in docs to 'r-lib'
- No great need to cache installed packages after we solved https://github.com/r-lib/rlang/issues/1776