### PR TITLE
Make `in_parallel()` fall back to sequential if daemons are not set

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Suggests:
     httr,
     knitr,
     lubridate,
-    mirai (>= 2.3.0),
+    mirai (>= 2.3.0.9001),
     rmarkdown,
     testthat (>= 3.0.0),
     tibble,
@@ -45,4 +45,6 @@ Config/testthat/parallel: TRUE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
-Remotes: r-lib/carrier
+Remotes:
+    r-lib/carrier,
+    r-lib/mirai

--- a/R/imap.R
+++ b/R/imap.R
@@ -13,6 +13,12 @@
 #'   * A formula, e.g. `~ .x + .y`. You must use `.x` to refer to the
 #'     current element and `.y` to refer to the current index. Only recommended
 #'     if you require backward compatibility with older versions of R.
+#'
+#'   `r lifecycle::badge("experimental")`
+#'
+#'   Wrap a function with [in_parallel()] to declare that it should be performed
+#'   in parallel. See [in_parallel()] for more details.
+#'   Use of `...` is not permitted in this context.
 #' @inheritParams map
 #' @return A vector the same length as `.x`.
 #' @export

--- a/R/map.R
+++ b/R/map.R
@@ -33,7 +33,7 @@
 #'
 #'   `r lifecycle::badge("experimental")`
 #'
-#'   Wrap a function with [in_parallel()] to declare that it should proceed
+#'   Wrap a function with [in_parallel()] to declare that it should be performed
 #'   in parallel. See [in_parallel()] for more details.
 #'   Use of `...` is not permitted in this context.
 #'
@@ -132,7 +132,7 @@
 #'   map(summary) |>
 #'   map_dbl("r.squared")
 #'
-#' @examplesIf interactive() && requireNamespace("mirai", quietly = TRUE) && requireNamespace("carrier", quietly = TRUE)
+#' @examplesIf interactive() && rlang::is_installed("mirai") && rlang::is_installed("carrier")
 #' # Run in interactive sessions only as spawns additional processes
 #'
 #' # To use parallelized map:
@@ -201,7 +201,7 @@ map_ <- function(.type,
   .x <- vctrs_vec_compat(.x, .purrr_user_env)
   vec_assert(.x, arg = ".x", call = .purrr_error_call)
 
-  if (is_crate(.f)) {
+  if (is_crate(.f) && parallel_pkgs_installed() && mirai::daemons_set()) {
     return(mmap_(.x, .f, .progress, .type, .purrr_error_call, ...))
   }
 
@@ -221,13 +221,6 @@ map_ <- function(.type,
 
 mmap_ <- function(.x, .f, .progress, .type, error_call, ...) {
 
-  check_parallel_pkgs()
-  if (!mirai::daemons_set()) {
-    cli::cli_abort(
-      "No daemons set - use e.g. {.run mirai::daemons(6)} to set 6 local daemons.",
-      call = error_call
-    )
-  }
   if (...length()) {
     cli::cli_abort(
       "Can't use `...` with parallelized functions.",

--- a/R/map2.R
+++ b/R/map2.R
@@ -14,6 +14,12 @@
 #'     element of `x` and `.y` to refer to the current element of `y`. Only
 #'     recommended if you require backward compatibility with older versions
 #'     of R.
+#'
+#'   `r lifecycle::badge("experimental")`
+#'
+#'   Wrap a function with [in_parallel()] to declare that it should be performed
+#'   in parallel. See [in_parallel()] for more details.
+#'   Use of `...` is not permitted in this context.
 #' @inheritParams map
 #' @inherit map return
 #' @family map variants
@@ -74,7 +80,7 @@ map2_ <- function(.type,
 
   .f <- as_mapper(.f, ...)
 
-  if (is_crate(.f)) {
+  if (is_crate(.f) && parallel_pkgs_installed() && mirai::daemons_set()) {
     attributes(args) <- list(
       class = "data.frame",
       row.names = if (is.null(names)) .set_row_names(n) else names

--- a/R/parallelization.R
+++ b/R/parallelization.R
@@ -18,8 +18,9 @@
 #'    large objects between processes.
 #'
 #' For maps to actually be performed in parallel, the user must also set
-#' [mirai::daemons()], otherwise they fall back to sequential processing - see
-#' the section 'Daemons settings' below.
+#' [mirai::daemons()], otherwise they fall back to sequential processing.
+#' [mirai::require_daemons()] may be used to enforce the use of parallel
+#' processing. See the section 'Daemons settings' below.
 #'
 #' @param .f A fresh formula or function. "Fresh" here means that they should be
 #'   declared in the call to [in_parallel()].
@@ -81,7 +82,9 @@
 #' local machine or across the network.
 #'
 #' Daemons must be set prior to performing any parallel map operation, otherwise
-#' [in_parallel()] will fall back to sequential processing.
+#' [in_parallel()] will fall back to sequential processing. To ensure that maps
+#' are always performed in parallel, put [mirai::require_daemons()] before the
+#' map.
 #'
 #' It is usual to set daemons once per session. You can leave them running on
 #' your local machine as they consume almost no resources whilst waiting to

--- a/R/pmap.R
+++ b/R/pmap.R
@@ -22,6 +22,12 @@
 #'     `function(x, y, z) x + y / z`
 #'   * A formula, e.g. `~ ..1 + ..2 / ..3`. This syntax is not recommended as
 #'     you can only refer to arguments by position.
+#'
+#'   `r lifecycle::badge("experimental")`
+#'
+#'   Wrap a function with [in_parallel()] to declare that it should be performed
+#'   in parallel. See [in_parallel()] for more details.
+#'   Use of `...` is not permitted in this context.
 #' @inheritParams map
 #' @returns
 #' The output length is determined by the maximum length of all elements of `.l`.

--- a/man/imap.Rd
+++ b/man/imap.Rd
@@ -35,7 +35,13 @@ iwalk(.x, .f, ...)
 \item A formula, e.g. \code{~ .x + .y}. You must use \code{.x} to refer to the
 current element and \code{.y} to refer to the current index. Only recommended
 if you require backward compatibility with older versions of R.
-}}
+}
+
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+
+Wrap a function with \code{\link[=in_parallel]{in_parallel()}} to declare that it should be performed
+in parallel. See \code{\link[=in_parallel]{in_parallel()}} for more details.
+Use of \code{...} is not permitted in this context.}
 
 \item{...}{Additional arguments passed on to the mapped function.
 

--- a/man/in_parallel.Rd
+++ b/man/in_parallel.Rd
@@ -36,8 +36,9 @@ large objects between processes.
 }
 
 For maps to actually be performed in parallel, the user must also set
-\code{\link[mirai:daemons]{mirai::daemons()}}, otherwise they fall back to sequential processing - see
-the section 'Daemons settings' below.
+\code{\link[mirai:daemons]{mirai::daemons()}}, otherwise they fall back to sequential processing.
+\code{\link[mirai:require_daemons]{mirai::require_daemons()}} may be used to enforce the use of parallel
+processing. See the section 'Daemons settings' below.
 }
 \section{Creating self-contained functions}{
 
@@ -98,7 +99,9 @@ This is a function from the \pkg{mirai} package that sets up daemons
 local machine or across the network.
 
 Daemons must be set prior to performing any parallel map operation, otherwise
-\code{\link[=in_parallel]{in_parallel()}} will fall back to sequential processing.
+\code{\link[=in_parallel]{in_parallel()}} will fall back to sequential processing. To ensure that maps
+are always performed in parallel, put \code{\link[mirai:require_daemons]{mirai::require_daemons()}} before the
+map.
 
 It is usual to set daemons once per session. You can leave them running on
 your local machine as they consume almost no resources whilst waiting to

--- a/man/in_parallel.Rd
+++ b/man/in_parallel.Rd
@@ -31,9 +31,13 @@ computations in parallel.
 \item It helps you create self-contained functions that are isolated from your
 workspace. This is important because the function is packaged up
 (serialized) to be sent across to parallel processes. Isolation is
-critical for performance because it prevents sending very large objects
-without the intention.
+critical for performance because it prevents accidentally sending very
+large objects between processes.
 }
+
+For maps to actually be performed in parallel, the user must also set
+\code{\link[mirai:daemons]{mirai::daemons()}}, otherwise they fall back to sequential processing - see
+the section 'Daemons settings' below.
 }
 \section{Creating self-contained functions}{
 
@@ -93,10 +97,12 @@ This is a function from the \pkg{mirai} package that sets up daemons
 (persistent background processes that receive parallel computations) on your
 local machine or across the network.
 
-Daemons must be set up prior to performing any parallel map operation. It is
-usual to set daemons once per session. You can leave them running on your
-local machine as they consume almost no resources whilst waiting to receive
-tasks. The following sets up 6 daemons on your local machine:
+Daemons must be set prior to performing any parallel map operation, otherwise
+\code{\link[=in_parallel]{in_parallel()}} will fall back to sequential processing.
+
+It is usual to set daemons once per session. You can leave them running on
+your local machine as they consume almost no resources whilst waiting to
+receive tasks. The following sets up 6 daemons locally:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{mirai::daemons(6)
 }\if{html}{\out{</div>}}
@@ -126,12 +132,14 @@ practice to do so.
 
 Note: it should always be for the user to set daemons. If you are using
 parallel map within a package, do not make any \code{\link[mirai:daemons]{mirai::daemons()}} calls
-within the package. This helps prevent inadvertently spawning too many
-daemons if functions are used recursively within each other.
+within the package, as it should always be up to the user how they wish to
+set up parallel processing e.g. using local or remote daemons. This also
+helps prevent inadvertently spawning too many daemons if functions are used
+recursively within each other.
 }
 
 \examples{
-\dontshow{if (interactive() && requireNamespace("mirai", quietly = TRUE) && requireNamespace("carrier", quietly = TRUE)) withAutoprint(\{ # examplesIf}
+\dontshow{if (interactive() && rlang::is_installed("mirai") && rlang::is_installed("carrier")) withAutoprint(\{ # examplesIf}
 # Run in interactive sessions only as spawns additional processes
 
 slow_lm <- function(formula, data) {

--- a/man/map.Rd
+++ b/man/map.Rd
@@ -42,7 +42,7 @@ set a default value if the indexed element is \code{NULL} or does not exist.
 
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 
-Wrap a function with \code{\link[=in_parallel]{in_parallel()}} to declare that it should proceed
+Wrap a function with \code{\link[=in_parallel]{in_parallel()}} to declare that it should be performed
 in parallel. See \code{\link[=in_parallel]{in_parallel()}} for more details.
 Use of \code{...} is not permitted in this context.}
 
@@ -156,7 +156,7 @@ mtcars |>
   map(summary) |>
   map_dbl("r.squared")
 
-\dontshow{if (interactive() && requireNamespace("mirai", quietly = TRUE) && requireNamespace("carrier", quietly = TRUE)) withAutoprint(\{ # examplesIf}
+\dontshow{if (interactive() && rlang::is_installed("mirai") && rlang::is_installed("carrier")) withAutoprint(\{ # examplesIf}
 # Run in interactive sessions only as spawns additional processes
 
 # To use parallelized map:

--- a/man/map2.Rd
+++ b/man/map2.Rd
@@ -36,7 +36,13 @@ of length 1 will be recycled to the length of the other.}
 element of \code{x} and \code{.y} to refer to the current element of \code{y}. Only
 recommended if you require backward compatibility with older versions
 of R.
-}}
+}
+
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+
+Wrap a function with \code{\link[=in_parallel]{in_parallel()}} to declare that it should be performed
+in parallel. See \code{\link[=in_parallel]{in_parallel()}} for more details.
+Use of \code{...} is not permitted in this context.}
 
 \item{...}{Additional arguments passed on to the mapped function.
 

--- a/man/map_depth.Rd
+++ b/man/map_depth.Rd
@@ -35,7 +35,7 @@ set a default value if the indexed element is \code{NULL} or does not exist.
 
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 
-Wrap a function with \code{\link[=in_parallel]{in_parallel()}} to declare that it should proceed
+Wrap a function with \code{\link[=in_parallel]{in_parallel()}} to declare that it should be performed
 in parallel. See \code{\link[=in_parallel]{in_parallel()}} for more details.
 Use of \code{...} is not permitted in this context.}
 

--- a/man/map_if.Rd
+++ b/man/map_if.Rd
@@ -34,7 +34,7 @@ set a default value if the indexed element is \code{NULL} or does not exist.
 
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 
-Wrap a function with \code{\link[=in_parallel]{in_parallel()}} to declare that it should proceed
+Wrap a function with \code{\link[=in_parallel]{in_parallel()}} to declare that it should be performed
 in parallel. See \code{\link[=in_parallel]{in_parallel()}} for more details.
 Use of \code{...} is not permitted in this context.}
 

--- a/man/pmap.Rd
+++ b/man/pmap.Rd
@@ -42,7 +42,13 @@ to be called once for each row.}
 \code{function(x, y, z) x + y / z}
 \item A formula, e.g. \code{~ ..1 + ..2 / ..3}. This syntax is not recommended as
 you can only refer to arguments by position.
-}}
+}
+
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+
+Wrap a function with \code{\link[=in_parallel]{in_parallel()}} to declare that it should be performed
+in parallel. See \code{\link[=in_parallel]{in_parallel()}} for more details.
+Use of \code{...} is not permitted in this context.}
 
 \item{...}{Additional arguments passed on to the mapped function.
 

--- a/tests/testthat/_snaps/parallel.md
+++ b/tests/testthat/_snaps/parallel.md
@@ -1,11 +1,3 @@
-# Can't parallel map without first setting daemons
-
-    Code
-      map(list(x = 1, y = 2), in_parallel(function(x) list(x)))
-    Condition
-      Error in `map()`:
-      ! No daemons set - use e.g. `mirai::daemons(6)` to set 6 local daemons.
-
 # Can't use `...` in a parallel map
 
     Code

--- a/tests/testthat/test-parallel.R
+++ b/tests/testthat/test-parallel.R
@@ -1,9 +1,10 @@
 skip_if_not_installed("mirai")
 
-test_that("Can't parallel map without first setting daemons", {
-  expect_snapshot(error = TRUE, {
-    map(list(x = 1, y = 2), in_parallel(\(x) list(x)))
-  })
+test_that("Parallel map falls back to sequential with no daemons set", {
+  expect_identical(
+    map(list(x = 1, y = 2), in_parallel(\(x) list(x))),
+    map(list(x = 1, y = 2), \(x) list(x))
+  )
 })
 
 # set up daemons


### PR DESCRIPTION
Closes #1186.

To ease programmatic use of purrr within other (package) functions.

From a developer's perspective, compute should just be performed with whatever resources the user has available. The resources are declared by the `mirai::daemons()` call. If a user has not set this then sequential is the only safe fallback.

The onus is then on the developer to inform users that they *should* be calling `mirai::daemons()` to take advantage of parallel processing.

If the nature of things is that a function should always be run in parallel (or so that users don't easily forget to set daemons), a new function in mirai `mirai::require_daemons()` allows a developer to easily put this check before the map call. This basically replicates the behaviour we have now prior to this PR.