### PR TITLE
Require released versions of carrier and mirai

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,13 +22,13 @@ Imports:
     rlang (>= 1.1.1),
     vctrs (>= 0.6.3)
 Suggests: 
-    carrier (>= 0.1.1.9000),
+    carrier (>= 0.2.0),
     covr,
     dplyr (>= 0.7.8),
     httr,
     knitr,
     lubridate,
-    mirai (>= 2.3.0.9001),
+    mirai (>= 2.4.0),
     rmarkdown,
     testthat (>= 3.0.0),
     tibble,
@@ -45,6 +45,3 @@ Config/testthat/parallel: TRUE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
-Remotes:
-    r-lib/carrier,
-    r-lib/mirai

--- a/R/parallelization.R
+++ b/R/parallelization.R
@@ -170,7 +170,7 @@ parallel_pkgs_installed <- function() {
   is.logical(the$parallel_pkgs_installed) || {
     check_installed(
       c("carrier", "mirai"),
-      version = c("0.1.1.9000", "2.3.0"),
+      version = c("0.2.0", "2.4.0"),
       reason = "for parallel map."
     )
     the$parallel_pkgs_installed <- TRUE


### PR DESCRIPTION
Updates for carrier 0.2.0 and mirai 2.4.0.