### PR TITLE
Correct example in parallelization docs

### DIFF
--- a/R/parallelization.R
+++ b/R/parallelization.R
@@ -53,9 +53,9 @@
 #' mtcars |> map_dbl(in_parallel(\(x) sum(x)))
 #'
 #' # Package functions need to be explicitly namespaced, so instead of:
-#' map(1:3, in_parallel(\(x) runif(x)))
-#' # Use :: to namespace all packages, even those on the default search path:
-#' map(1:3, in_parallel(\(x) stats::runif(x)))
+#' map(1:3, in_parallel(\(x) vec_init(integer(), x)))
+#' # Use :: to namespace all package functions:
+#' map(1:3, in_parallel(\(x) vctrs::vec_init(integer(), x)))
 #'
 #' fun <- function(x) { x + x %% 2 }
 #' # Operating in parallel, locally-defined objects will not be found:

--- a/man/in_parallel.Rd
+++ b/man/in_parallel.Rd
@@ -66,9 +66,9 @@ mtcars |> map_dbl(in_parallel(sum))
 mtcars |> map_dbl(in_parallel(\\(x) sum(x)))
 
 # Package functions need to be explicitly namespaced, so instead of:
-map(1:3, in_parallel(\\(x) runif(x)))
-# Use :: to namespace all packages, even those on the default search path:
-map(1:3, in_parallel(\\(x) stats::runif(x)))
+map(1:3, in_parallel(\\(x) vec_init(integer(), x)))
+# Use :: to namespace all package functions:
+map(1:3, in_parallel(\\(x) vctrs::vec_init(integer(), x)))
 
 fun <- function(x) \{ x + x \%\% 2 \}
 # Operating in parallel, locally-defined objects will not be found:


### PR DESCRIPTION
As carrier behaviour has changed in 0.2.0 and the function is now attached to the search path.
Updated to use the same vctrs example we use in the `map()` examples.