### PR TITLE
Allow fallback to sequential for parallel `pmap()`

### DIFF
--- a/R/pmap.R
+++ b/R/pmap.R
@@ -150,7 +150,7 @@ pmap_ <- function(
 
   .f <- as_mapper(.f, ...)
 
-  if (is_crate(.f)) {
+  if (is_crate(.f) && parallel_pkgs_installed() && mirai::daemons_set()) {
     attributes(.l) <- list(
       names = names(.l),
       class = "data.frame",

--- a/tests/testthat/test-parallel.R
+++ b/tests/testthat/test-parallel.R
@@ -1,10 +1,12 @@
 skip_if_not_installed("mirai")
 
-test_that("Parallel map falls back to sequential with no daemons set", {
+test_that("All parallel map variants fall back to sequential with no daemons set", {
   expect_identical(
     map(list(x = 1, y = 2), in_parallel(\(x) list(x))),
     map(list(x = 1, y = 2), \(x) list(x))
   )
+  expect_equal(map2(1, 2, in_parallel(\(x, y) x)), list(1))
+  expect_identical(pmap(list(), in_parallel(~ 1)), list())
 })
 
 # set up daemons


### PR DESCRIPTION
Fixes #1198.

This was a missed code path when we updated `map()` and `map2()` to fall back to sequential. Includes tests.