### PR TITLE
Enable passing strings and lists to `.progress` when `in_parallel()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,4 +47,4 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 Remotes:
     r-lib/carrier,
-    r-lib/mirai@purrr
+    r-lib/mirai

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Suggests:
     httr,
     knitr,
     lubridate,
-    mirai (>= 2.4.0),
+    mirai (>= 2.4.1.9002),
     rmarkdown,
     testthat (>= 3.0.0),
     tibble,
@@ -45,4 +45,6 @@ Config/testthat/parallel: TRUE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
-Remotes: r-lib/carrier
+Remotes:
+    r-lib/carrier,
+    r-lib/mirai@purrr

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * `in_parallel()` now accepts objects, including helper functions, supplied to `...` for all locally-defined functions (#1208).
 
+* `in_parallel()` now works in conjunction with string and list values supplied to the `.progress` argument of map functions (#1203).
+
 * All functions that were soft-deprecated in purrr 1.0.0 are now fully deprecated. They will be removed in a future release. This includes: `invoke_*()`, `lift_*()`, `cross*()`, `prepend()`, `splice()`, `rbernoulli()`, `rdunif()`, `when()`, `update_list()`, `*_raw()`, `vec_depth()`.
 
 * `map_chr()` no longer coereces from logical, integer, or double to strings.

--- a/R/map.R
+++ b/R/map.R
@@ -229,7 +229,13 @@ mmap_ <- function(.x, .f, .progress, .type, error_call, ...) {
 
   m <- mirai::mirai_map(.x, .f)
 
-  options <- c(".stop", if (isTRUE(.progress)) ".progress")
+  options <- if (is.null(.progress)) {
+    ".stop"
+  } else if (isTRUE(.progress)) {
+    c(".stop", ".progress")
+  } else {
+    list(.progress)
+  }
   x <- with_parallel_indexed_errors(
     mirai::collect_mirai(m, options = options),
     interrupt_expr = mirai::stop_mirai(m),

--- a/R/map.R
+++ b/R/map.R
@@ -229,12 +229,17 @@ mmap_ <- function(.x, .f, .progress, .type, error_call, ...) {
 
   m <- mirai::mirai_map(.x, .f)
 
-  options <- if (is.null(.progress)) {
+  options <- if (isFALSE(.progress)) {
     ".stop"
-  } else if (isTRUE(.progress)) {
+  } else if (is.logical(.progress)) {
     c(".stop", ".progress")
+  } else if (is.character(.progress) || is.list(.progress)) {
+    list(.stop = TRUE, .progress = .progress)
   } else {
-    list(.progress)
+    cli::cli_abort(
+      "Unknown cli progress bar configuation, see manual.",
+      call = error_call
+    )
   }
   x <- with_parallel_indexed_errors(
     mirai::collect_mirai(m, options = options),

--- a/R/parallelization.R
+++ b/R/parallelization.R
@@ -187,7 +187,7 @@ parallel_pkgs_installed <- function() {
     {
       check_installed(
         c("carrier", "mirai"),
-        version = c("0.2.0.9000", "2.4.0"),
+        version = c("0.2.0.9000", "2.4.1.9002"),
         reason = "for parallel map."
       )
       the$parallel_pkgs_installed <- TRUE


### PR DESCRIPTION
Fixes #1203.

Makes use of a new interface in mirai, which lets a string or list value for `.progress` to be passed (implemented in https://github.com/r-lib/mirai/pull/416). This is ultimately passed on to `cli::cli_progress_bar()`.

This brings back parity to progress bar options between the parallel and non-parallel cases.