### PR TITLE
Update parallel dependencies with release versions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Suggests:
     httr,
     knitr,
     lubridate,
-    mirai (>= 2.4.1.9002),
+    mirai (>= 2.5.0),
     rmarkdown,
     testthat (>= 3.0.0),
     tibble,
@@ -46,5 +46,4 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 Remotes:
-    r-lib/carrier,
-    r-lib/mirai
+    r-lib/carrier

--- a/R/parallelization.R
+++ b/R/parallelization.R
@@ -187,7 +187,7 @@ parallel_pkgs_installed <- function() {
     {
       check_installed(
         c("carrier", "mirai"),
-        version = c("0.2.0.9000", "2.4.1.9002"),
+        version = c("0.2.0.9000", "2.5.0"),
         reason = "for parallel map."
       )
       the$parallel_pkgs_installed <- TRUE


### PR DESCRIPTION
- [ ] mirai 2.5.0
- [ ] carrier 0.3.0