### PR TITLE
modify error message to show .x argument name for one or more inputs

### DIFF
--- a/R/map.R
+++ b/R/map.R
@@ -281,10 +281,10 @@ with_indexed_errors <- function(
       if (i == 0L) {
         # Error happened before or after loop
       } else {
-        message <- c(i = "In index: {i}.")
+        message <- c(i = "In .x[[{i}]].")
         if (!is.null(names) && !is.na(names[[i]]) && names[[i]] != "") {
           name <- names[[i]]
-          message <- c(message, i = "With name: {name}.")
+          message <- paste(message, "with element name: {name}.", sep = " ")
         } else {
           name <- NULL
         }

--- a/tests/testthat/_snaps/keep.md
+++ b/tests/testthat/_snaps/keep.md
@@ -4,14 +4,14 @@
       keep(1:3, ~NA)
     Condition
       Error in `keep()`:
-      i In index: 1.
+      i In .x[[1]].
       Caused by error:
       ! `.p()` must return a single `TRUE` or `FALSE`, not `NA`.
     Code
       discard(1:3, ~NA)
     Condition
       Error in `discard()`:
-      i In index: 1.
+      i In .x[[1]].
       Caused by error:
       ! `.p()` must return a single `TRUE` or `FALSE`, not `NA`.
 

--- a/tests/testthat/_snaps/map-depth.md
+++ b/tests/testthat/_snaps/map-depth.md
@@ -4,11 +4,11 @@
       map_depth(x1, 6, length)
     Condition
       Error in `.fmap()`:
-      i In index: 1.
+      i In .x[[1]].
       Caused by error in `.fmap()`:
-      i In index: 1.
+      i In .x[[1]].
       Caused by error in `.fmap()`:
-      i In index: 1.
+      i In .x[[1]].
       Caused by error in `map_depth()`:
       ! List not deep enough
 
@@ -26,7 +26,7 @@
       map_depth(x, 2, class)
     Condition
       Error in `.fmap()`:
-      i In index: 1.
+      i In .x[[1]].
       Caused by error in `map_depth()`:
       ! List not deep enough
 
@@ -36,11 +36,11 @@
       modify_depth(x1, 5, length)
     Condition
       Error in `map()`:
-      i In index: 1.
+      i In .x[[1]].
       Caused by error in `map()`:
-      i In index: 1.
+      i In .x[[1]].
       Caused by error in `map()`:
-      i In index: 1.
+      i In .x[[1]].
       Caused by error in `modify_depth()`:
       ! List not deep enough
 
@@ -58,11 +58,11 @@
       modify_depth(x, 5, `+`, 10L)
     Condition
       Error in `map()`:
-      i In index: 1.
+      i In .x[[1]].
       Caused by error in `map()`:
-      i In index: 1.
+      i In .x[[1]].
       Caused by error in `map()`:
-      i In index: 1.
+      i In .x[[1]].
       Caused by error in `modify_depth()`:
       ! List not deep enough
 

--- a/tests/testthat/_snaps/map-if-at.md
+++ b/tests/testthat/_snaps/map-if-at.md
@@ -4,7 +4,7 @@
       map_if(1:3, ~NA, ~"foo")
     Condition
       Error in `map_if()`:
-      i In index: 1.
+      i In .x[[1]].
       Caused by error:
       ! `.p()` must return a single `TRUE` or `FALSE`, not `NA`.
 

--- a/tests/testthat/_snaps/map.md
+++ b/tests/testthat/_snaps/map.md
@@ -20,21 +20,21 @@
       map_int(1:3, ~ fail_at_3(.x, 2:1))
     Condition
       Error in `map_int()`:
-      i In index: 3.
+      i In .x[[3]].
       Caused by error:
       ! Result must be length 1, not 2.
     Code
       map_int(1:3, ~ fail_at_3(.x, "x"))
     Condition
       Error in `map_int()`:
-      i In index: 3.
+      i In .x[[3]].
       Caused by error:
       ! Can't coerce from a string to an integer.
     Code
       map(1:3, ~ fail_at_3(.x, stop("Doesn't work")))
     Condition
       Error in `map()`:
-      i In index: 3.
+      i In .x[[3]].
       Caused by error in `fail_at_3()`:
       ! Doesn't work
 
@@ -44,15 +44,14 @@
       map_int(c(a = 1, b = 2, c = 3), ~ fail_at_3(.x, stop("Error")))
     Condition
       Error in `map_int()`:
-      i In index: 3.
-      i With name: c.
+      ! In .x[[3]]. with element name: c.
       Caused by error in `fail_at_3()`:
       ! Error
     Code
       map_int(c(a = 1, b = 2, 3), ~ fail_at_3(.x, stop("Error")))
     Condition
       Error in `map_int()`:
-      i In index: 3.
+      i In .x[[3]].
       Caused by error in `fail_at_3()`:
       ! Error
 

--- a/tests/testthat/_snaps/map2.md
+++ b/tests/testthat/_snaps/map2.md
@@ -4,14 +4,14 @@
       map2_int(1, 1, ~"x")
     Condition
       Error in `map2_int()`:
-      i In index: 1.
+      i In .x[[1]].
       Caused by error:
       ! Can't coerce from a string to an integer.
     Code
       map2_int(1, 1, ~ 1:2)
     Condition
       Error in `map2_int()`:
-      i In index: 1.
+      i In .x[[1]].
       Caused by error:
       ! Result must be length 1, not 2.
     Code

--- a/tests/testthat/_snaps/modify.md
+++ b/tests/testthat/_snaps/modify.md
@@ -86,7 +86,7 @@
       modify_if(list(1, 2), ~NA, ~"foo")
     Condition
       Error in `modify_if()`:
-      i In index: 1.
+      i In .x[[1]].
       Caused by error:
       ! `.p()` must return a single `TRUE` or `FALSE`, not `NA`.
 

--- a/tests/testthat/_snaps/pmap.md
+++ b/tests/testthat/_snaps/pmap.md
@@ -4,14 +4,14 @@
       pmap_int(list(1), ~"x")
     Condition
       Error in `pmap_int()`:
-      i In index: 1.
+      i In .x[[1]].
       Caused by error:
       ! Can't coerce from a string to an integer.
     Code
       pmap_int(list(1), ~ 1:2)
     Condition
       Error in `pmap_int()`:
-      i In index: 1.
+      i In .x[[1]].
       Caused by error:
       ! Result must be length 1, not 2.
     Code


### PR DESCRIPTION
fix #1151 