### PR TITLE
Remove check for primitive/builtin in `as_mapper.default()` to improve performance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # purrr (development version)
 
+* Optimized `as_mapper.default()` by removing a check and handling of primitive function types. (#1088)
+
 * `list_flatten()` gains an `is_node` parameter taking a predicate function that determines whether an input element is a node or a leaf (@salim-b, #1179).
 
 * `in_parallel()` now accepts objects, including helper functions, supplied to `...` for all locally-defined functions (#1208).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # purrr (development version)
 
-* Optimized `as_mapper.default()` by removing a check and handling of primitive function types. (#1088)
+* `as_mapper.default()` optimized by removing special named argument handling for primitive functions (@mtcarsalot, #1088).
 
 * `list_flatten()` gains an `is_node` parameter taking a predicate function that determines whether an input element is a node or a leaf (@salim-b, #1179).
 

--- a/R/map-mapper.R
+++ b/R/map-mapper.R
@@ -43,18 +43,7 @@ as_mapper <- function(.f, ...) {
 
 #' @export
 as_mapper.default <- function(.f, ...) {
-  if (typeof(.f) %in% c("special", "builtin")) {
-    .f <- rlang::as_closure(.f)
-
-    # Workaround until fixed in rlang
-    if (is_reference(fn_env(.f), base_env())) {
-      environment(.f) <- global_env()
-    }
-
-    .f
-  } else {
     rlang::as_function(.f)
-  }
 }
 
 #' @export

--- a/R/map-mapper.R
+++ b/R/map-mapper.R
@@ -43,7 +43,7 @@ as_mapper <- function(.f, ...) {
 
 #' @export
 as_mapper.default <- function(.f, ...) {
-    rlang::as_function(.f)
+  rlang::as_function(.f)
 }
 
 #' @export

--- a/tests/testthat/test-map-mapper.R
+++ b/tests/testthat/test-map-mapper.R
@@ -51,7 +51,7 @@ test_that("can supply length > 1 vectors", {
 # primitive functions --------------------------------------------------
 
 test_that("primitive functions are wrapped", {
-  expect_identical(as_mapper(`-`)(x, 10), -5)
+  expect_identical(as_mapper(`-`)(.y = 10, .x = 5), 5)
   expect_identical(as_mapper(`c`)(1, 3, 5), c(1, 3, 5))
 })
 

--- a/tests/testthat/test-map-mapper.R
+++ b/tests/testthat/test-map-mapper.R
@@ -51,7 +51,7 @@ test_that("can supply length > 1 vectors", {
 # primitive functions --------------------------------------------------
 
 test_that("primitive functions are wrapped", {
-  expect_identical(as_mapper(`-`)(.y = 10, .x = 5), 5)
+  expect_identical(as_mapper(`-`)(x, 10), -5)
   expect_identical(as_mapper(`c`)(1, 3, 5), c(1, 3, 5))
 })
 

--- a/tests/testthat/test-map-mapper.R
+++ b/tests/testthat/test-map-mapper.R
@@ -51,7 +51,7 @@ test_that("can supply length > 1 vectors", {
 # primitive functions --------------------------------------------------
 
 test_that("primitive functions are wrapped", {
-  expect_identical(as_mapper(`-`)(.y = 10, .x = 5), 5)
+  expect_identical(as_mapper(`-`)(.y = 10, .x = 5), 5) # positional matching, not by name
   expect_identical(as_mapper(`c`)(1, 3, 5), c(1, 3, 5))
 })
 

--- a/tests/testthat/test-map-mapper.R
+++ b/tests/testthat/test-map-mapper.R
@@ -51,7 +51,7 @@ test_that("can supply length > 1 vectors", {
 # primitive functions --------------------------------------------------
 
 test_that("primitive functions are wrapped", {
-  expect_identical(as_mapper(`-`)(.y = 10, .x = 5), -5)
+  expect_identical(as_mapper(`-`)(.y = 10, .x = 5), 5)
   expect_identical(as_mapper(`c`)(1, 3, 5), c(1, 3, 5))
 })
 


### PR DESCRIPTION
- change test to reflect
- The func description did not mention primitives, so i did not explain that these are handled differently now...

Fixes #1088

performance before and after fix.

```
x <- as.list(1:20)
x[21] <- list(NULL)

bench::mark(
   wrapped = purrr::detect_index(x, function(x) is.null(x)),
   prim = purrr::detect_index(x, is.null)
)
# A tibble: 2 × 13
  expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result    memory              time       gc      
  <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list>    <list>              <list>     <list>  
1 wrapped      62.3µs   65.6µs    13760.    4.12KB     6.29  6563     3      477ms <int [1]> <Rprofmem [12 × 3]> <bench_tm> <tibble>
2 prim        137.4µs  143.7µs     6502.        0B     6.28  3108     3      478ms <int [1]> <Rprofmem [0 × 3]>  <bench_tm> <tibble>

 devtools::load_all()
ℹ Loading purrr

bench::mark(
   wrapped = purrr::detect_index(x, function(x) is.null(x)),
   prim = purrr::detect_index(x, is.null) 
)
# A tibble: 2 × 13
  expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result    memory              time       gc      
  <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list>    <list>              <list>     <list>  
1 wrapped        75µs   78.1µs    12529.    4.12KB     6.31  5955     3      475ms <int [1]> <Rprofmem [12 × 3]> <bench_tm> <tibble>
2 prim         69.3µs   72.7µs    13506.    30.8KB     8.52  6338     4      469ms <int [1]> <Rprofmem [68 × 3]> <bench_tm> <tibble>
```