### PR TITLE
Update  `pluck`/`chuck`/`keep_at`/`discard_at` documentation

### DIFF
--- a/R/keep.R
+++ b/R/keep.R
@@ -62,20 +62,14 @@ compact <- function(.x, .p = identity) {
 
 #' Keep/discard elements based on their name/position
 #'
+#' @description
+#' `keep_at()` and `discard_at()` are similar to `[` or `dplyr::select()`: they
+#' return the same type of data structure as the input, but only containing
+#' the requested elements. (If you're looking for a function similar to
+#' `[[` see [pluck()]/[chuck()]).
+#'
+#' @seealso [keep()]/[discard()] to keep/discard elements by value.
 #' @inheritParams map_at
-#' @details
-#' * You can think of `keep_at()` as the equivalent of `dplyr::select()` for data frames
-#'   in that keep_at will retrieve the values out of a list and return those values
-#'   in it's original list form instead of a vector like `pluck()` or `chuck()` would.
-#'
-#' * `discard_at()` is similar to using negating operators with `dplyr::select()`
-#'   for dropping columns in data frames, in that discard_at will drop the list
-#'   elements passed through to it.
-#'
-#' @seealso [keep()]/[discard()] to keep/discard elements by value. [pluck()]/[chuck()]
-#'   is similar to `keep_at()` as it will also retrieve values from a list, but will
-#'   return the value from the list in a vector instead of retaining the structure of
-#'   the list element itself.
 #' @export
 #' @examples
 #' x <- c(a = 1, b = 2, cat = 10, dog = 15, elephant = 5, e = 10)

--- a/R/keep.R
+++ b/R/keep.R
@@ -63,7 +63,19 @@ compact <- function(.x, .p = identity) {
 #' Keep/discard elements based on their name/position
 #'
 #' @inheritParams map_at
-#' @seealso [keep()]/[discard()] to keep/discard elements by value.
+#' @details
+#' * You can think of `keep_at()` as the equivalent of `dplyr::select()` for data frames
+#'   in that keep_at will retrieve the values out of a list and return those values
+#'   in it's original list form instead of a vector like `pluck()` or `chuck()` would.
+#'
+#' * `discard_at()` is similar to using negating operators with `dplyr::select()`
+#'   for dropping columns in data frames, in that discard_at will drop the list
+#'   elements passed through to it.
+#'
+#' @seealso [keep()]/[discard()] to keep/discard elements by value. [pluck()]/[chuck()]
+#'   is similar to `keep_at()` as it will also retrieve values from a list, but will
+#'   return the value from the list in a vector instead of retaining the structure of
+#'   the list element itself.
 #' @export
 #' @examples
 #' x <- c(a = 1, b = 2, cat = 10, dog = 15, elephant = 5, e = 10)

--- a/R/pluck.R
+++ b/R/pluck.R
@@ -2,8 +2,10 @@
 #'
 #' @description
 #' `pluck()` implements a generalised form of `[[` that allow you to index
-#' deeply and flexibly into data structures. It always succeeds, returning
+#' deeply and flexibly into data structures. (If you're looking for an
+#' equivalent of `[`, see [keep_at()].) `pluck()` always succeeds, returning
 #' `.default` if the index you are trying to access does not exist or is `NULL`.
+#' (If you're looking for a variant that errors, try [chuck()].)
 #'
 #' `pluck<-()` is the assignment equivalent, allowing you to modify an object
 #' deep within a nested data structure.
@@ -39,14 +41,11 @@
 #' * These accessors never partial-match. This is unlike `$` which
 #'   will select the `disp` object if you write `mtcars$di`.
 #'
-#' * You can think of pluck or chuck as the equivalent of `dplyr::pull()` for data frames
-#'   in that pluck and chuck will retrieve the values out of a list and return those values
-#'   in a vector.
-#'
-#' @seealso [attr_getter()] for creating attribute getters suitable
-#'   for use with `pluck()` and `chuck()`. [modify_in()] for
-#'   applying a function to a pluck location. `keep_at()` is similar to `pluck()`
-#'   as it will also retrieve values from a list, but will retain the structure
+#' @seealso
+#' * [attr_getter()] for creating attribute getters suitable for use
+#'   with `pluck()` and `chuck()`.
+#' * [modify_in()] for applying a function to a plucked location.
+#' * [keep_at()] is similar to `pluck()`, but retain the structure
 #'   of the list instead of converting it into a vector.
 #' @export
 #' @examples

--- a/R/pluck.R
+++ b/R/pluck.R
@@ -39,9 +39,15 @@
 #' * These accessors never partial-match. This is unlike `$` which
 #'   will select the `disp` object if you write `mtcars$di`.
 #'
+#' * You can think of pluck or chuck as the equivalent of `dplyr::pull()` for data frames
+#'   in that pluck and chuck will retrieve the values out of a list and return those values
+#'   in a vector.
+#'
 #' @seealso [attr_getter()] for creating attribute getters suitable
 #'   for use with `pluck()` and `chuck()`. [modify_in()] for
-#'   applying a function to a pluck location.
+#'   applying a function to a pluck location. `keep_at()` is similar to `pluck()`
+#'   as it will also retrieve values from a list, but will retain the structure
+#'   of the list instead of converting it into a vector.
 #' @export
 #' @examples
 #' # Let's create a list of data structures:

--- a/man/keep_at.Rd
+++ b/man/keep_at.Rd
@@ -23,6 +23,16 @@ elements.}
 \description{
 Keep/discard elements based on their name/position
 }
+\details{
+\itemize{
+\item You can think of \code{keep_at()} as the equivalent of \code{dplyr::select()} for data frames
+in that keep_at will retrieve the values out of a list and return those values
+in it's original list form instead of a vector like \code{pluck()} or \code{chuck()} would.
+\item \code{discard_at()} is similar to using negating operators with \code{dplyr::select()}
+for dropping columns in data frames, in that discard_at will drop the list
+elements passed through to it.
+}
+}
 \examples{
 x <- c(a = 1, b = 2, cat = 10, dog = 15, elephant = 5, e = 10)
 x |> keep_at(letters)
@@ -33,5 +43,8 @@ x |> keep_at(\(x) nchar(x) == 3)
 x |> discard_at(\(x) nchar(x) == 3)
 }
 \seealso{
-\code{\link[=keep]{keep()}}/\code{\link[=discard]{discard()}} to keep/discard elements by value.
+\code{\link[=keep]{keep()}}/\code{\link[=discard]{discard()}} to keep/discard elements by value. \code{\link[=pluck]{pluck()}}/\code{\link[=chuck]{chuck()}}
+is similar to \code{keep_at()} as it will also retrieve values from a list, but will
+return the value from the list in a vector instead of retaining the structure of
+the list element itself.
 }

--- a/man/keep_at.Rd
+++ b/man/keep_at.Rd
@@ -21,17 +21,10 @@ installed, you can use \code{vars()} and tidyselect helpers to select
 elements.}
 }
 \description{
-Keep/discard elements based on their name/position
-}
-\details{
-\itemize{
-\item You can think of \code{keep_at()} as the equivalent of \code{dplyr::select()} for data frames
-in that keep_at will retrieve the values out of a list and return those values
-in it's original list form instead of a vector like \code{pluck()} or \code{chuck()} would.
-\item \code{discard_at()} is similar to using negating operators with \code{dplyr::select()}
-for dropping columns in data frames, in that discard_at will drop the list
-elements passed through to it.
-}
+\code{keep_at()} and \code{discard_at()} are similar to \code{[} or \code{dplyr::select()}: they
+return the same type of data structure as the input, but only containing
+the requested elements. (If you're looking for a function similar to
+\code{[[} see \code{\link[=pluck]{pluck()}}/\code{\link[=chuck]{chuck()}}).
 }
 \examples{
 x <- c(a = 1, b = 2, cat = 10, dog = 15, elephant = 5, e = 10)
@@ -43,8 +36,5 @@ x |> keep_at(\(x) nchar(x) == 3)
 x |> discard_at(\(x) nchar(x) == 3)
 }
 \seealso{
-\code{\link[=keep]{keep()}}/\code{\link[=discard]{discard()}} to keep/discard elements by value. \code{\link[=pluck]{pluck()}}/\code{\link[=chuck]{chuck()}}
-is similar to \code{keep_at()} as it will also retrieve values from a list, but will
-return the value from the list in a vector instead of retaining the structure of
-the list element itself.
+\code{\link[=keep]{keep()}}/\code{\link[=discard]{discard()}} to keep/discard elements by value.
 }

--- a/man/pluck.Rd
+++ b/man/pluck.Rd
@@ -33,8 +33,10 @@ Use \code{zap()} to instead remove the element.}
 }
 \description{
 \code{pluck()} implements a generalised form of \code{[[} that allow you to index
-deeply and flexibly into data structures. It always succeeds, returning
+deeply and flexibly into data structures. (If you're looking for an
+equivalent of \code{[}, see \code{\link[=keep_at]{keep_at()}}.) \code{pluck()} always succeeds, returning
 \code{.default} if the index you are trying to access does not exist or is \code{NULL}.
+(If you're looking for a variant that errors, try \code{\link[=chuck]{chuck()}}.)
 
 \verb{pluck<-()} is the assignment equivalent, allowing you to modify an object
 deep within a nested data structure.
@@ -55,9 +57,6 @@ because it reads linearly and is free of syntactic
 cruft. Compare: \code{accessor(x[[1]])$foo} to \code{pluck(x, 1, accessor, "foo")}.
 \item These accessors never partial-match. This is unlike \code{$} which
 will select the \code{disp} object if you write \code{mtcars$di}.
-\item You can think of pluck or chuck as the equivalent of \code{dplyr::pull()} for data frames
-in that pluck and chuck will retrieve the values out of a list and return those values
-in a vector.
 }
 }
 \examples{
@@ -114,9 +113,11 @@ idx <- list(1, my_element)
 pluck(x, !!!idx)
 }
 \seealso{
-\code{\link[=attr_getter]{attr_getter()}} for creating attribute getters suitable
-for use with \code{pluck()} and \code{chuck()}. \code{\link[=modify_in]{modify_in()}} for
-applying a function to a pluck location. \code{keep_at()} is similar to \code{pluck()}
-as it will also retrieve values from a list, but will retain the structure
+\itemize{
+\item \code{\link[=attr_getter]{attr_getter()}} for creating attribute getters suitable for use
+with \code{pluck()} and \code{chuck()}.
+\item \code{\link[=modify_in]{modify_in()}} for applying a function to a plucked location.
+\item \code{\link[=keep_at]{keep_at()}} is similar to \code{pluck()}, but retain the structure
 of the list instead of converting it into a vector.
+}
 }

--- a/man/pluck.Rd
+++ b/man/pluck.Rd
@@ -55,6 +55,9 @@ because it reads linearly and is free of syntactic
 cruft. Compare: \code{accessor(x[[1]])$foo} to \code{pluck(x, 1, accessor, "foo")}.
 \item These accessors never partial-match. This is unlike \code{$} which
 will select the \code{disp} object if you write \code{mtcars$di}.
+\item You can think of pluck or chuck as the equivalent of \code{dplyr::pull()} for data frames
+in that pluck and chuck will retrieve the values out of a list and return those values
+in a vector.
 }
 }
 \examples{
@@ -113,5 +116,7 @@ pluck(x, !!!idx)
 \seealso{
 \code{\link[=attr_getter]{attr_getter()}} for creating attribute getters suitable
 for use with \code{pluck()} and \code{chuck()}. \code{\link[=modify_in]{modify_in()}} for
-applying a function to a pluck location.
+applying a function to a pluck location. \code{keep_at()} is similar to \code{pluck()}
+as it will also retrieve values from a list, but will retain the structure
+of the list instead of converting it into a vector.
 }


### PR DESCRIPTION
- Fixes #1183
- Diff [here](https://github.com/tidyverse/purrr/pull/1219/files)
- Added references to `dplyr::pull()` and `dplyr::select()` functions in `pluck()`/`chuck()`/`keep_at()`/`discard_at()` documentation.
- Can confirm R CMD check passes locally:
<img width="1213" height="121" alt="Screenshot 2025-09-19 122618" src="https://github.com/user-attachments/assets/ec737d1b-d5e8-4a30-bda6-ec97c5a069c0" />

----

> [!NOTE]
> - I'm unsure if my language/additions are clear enough or if I misunderstood the issue. 
>
> - Also noticed some sections are not included in all functions, For example, a `@details` section was already [declared in `pluck()` in main](https://github.com/tidyverse/purrr/blob/8b270f7c656db9006855465d39a9f08d18dc8de8/R/pluck.R#L28-L40) but a `@details` section is not included in `keep_at()` on main. For consistency, I've added a `@details` section to `keep_at()`.