### PR TITLE
check mentions of formulas, specifiy backward compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ TAGS
 docs
 compile_commands.json
 .cache
+
+/.quarto/

--- a/R/detect.R
+++ b/R/detect.R
@@ -6,8 +6,8 @@
 #'
 #'   * A named function, e.g. `mean`.
 #'   * An anonymous function, e.g. `\(x) x + 1` or `function(x) x + 1`.
-#'   * A formula, e.g. `~ .x + 1`. You must use `.x` to refer to the first
-#'     argument. No longer recommended.
+#'   A formula, e.g. `~ .x + 1`. Only recommended if you require backward
+#'     compatibility with older versions of R.
 #'   * A string, integer, or list, e.g. `"idx"`, `1`, or `list("idx", 1)` which
 #'     are shorthand for `\(x) pluck(x, "idx")`, `\(x) pluck(x, 1)`, and
 #'     `\(x) pluck(x, "idx", 1)` respectively. Optionally supply `.default` to
@@ -50,7 +50,13 @@
 #'
 #' # If you need to find all positions, use map_lgl():
 #' which(map_lgl(x, "foo"))
-detect <- function(.x, .f, ..., .dir = c("forward", "backward"), .default = NULL) {
+detect <- function(
+  .x,
+  .f,
+  ...,
+  .dir = c("forward", "backward"),
+  .default = NULL
+) {
   .f <- as_predicate(.f, ..., .mapper = TRUE)
   .dir <- arg_match0(.dir, c("forward", "backward"))
 

--- a/R/imap.R
+++ b/R/imap.R
@@ -10,9 +10,8 @@
 #'   * A named function, e.g. `paste`.
 #'   * An anonymous function, e.g. `\(x, idx) x + idx` or
 #'     `function(x, idx) x + idx`.
-#'   * A formula, e.g. `~ .x + .y`. You must use `.x` to refer to the
-#'     current element and `.y` to refer to the current index.
-#'     No longer recommended.
+#'   * A formula, e.g. `~ .x + .y`. Use `.x` to refer to the current element and `.y` to refer to the current index.
+#'     Only recommended if you require backward compatibility with older versions of R.
 #'
 #'   `r lifecycle::badge("experimental")`
 #'

--- a/R/keep.R
+++ b/R/keep.R
@@ -15,8 +15,8 @@
 #'
 #'   * A named function, e.g. `is.character`.
 #'   * An anonymous function, e.g. `\(x) all(x < 0)` or `function(x) all(x < 0)`.
-#'   * A formula, e.g. `~ all(.x < 0)`. You must use `.x` to refer to the first
-#'     argument). No longer recommended.
+#'   * A formula, e.g. `~ all(.x < 0)`. Only recommended if you require backward
+#'     compatibility with older versions of R.
 #' @seealso [keep_at()]/[discard_at()] to keep/discard elements by name.
 #' @param ... Additional arguments passed on to `.p`.
 #' @export

--- a/R/map-mapper.R
+++ b/R/map-mapper.R
@@ -10,7 +10,7 @@
 #'   If a __function__, it is used as is.
 #'
 #'   If a __formula__, e.g. `~ .x + 2`, it is converted to a function.
-#'   No longer recommended.
+#'   Only recommended if you require backward compatibility with older versions of R.
 #'
 #'   If __character vector__, __numeric vector__, or __list__, it is
 #'   converted to an extractor function. Character vectors index by

--- a/R/map.R
+++ b/R/map.R
@@ -23,8 +23,8 @@
 #'
 #'   * A named function, e.g. `mean`.
 #'   * An anonymous function, e.g. `\(x) x + 1` or `function(x) x + 1`.
-#'   * A formula, e.g. `~ .x + 1`. You must use `.x` to refer to the first
-#'     argument. No longer recommended.
+#'   * A formula, e.g. `~ .x + 1`. Use `.x` to refer to the first
+#'     argument. Only recommended if you require backward compatibility with older versions of R.
 #'   * A string, integer, or list, e.g. `"idx"`, `1`, or `list("idx", 1)` which
 #'     are shorthand for `\(x) pluck(x, "idx")`, `\(x) pluck(x, 1)`, and
 #'     `\(x) pluck(x, "idx", 1)` respectively. Optionally supply `.default` to

--- a/R/map2.R
+++ b/R/map2.R
@@ -10,9 +10,9 @@
 #'
 #'   * A named function.
 #'   * An anonymous function, e.g. `\(x, y) x + y` or `function(x, y) x + y`.
-#'   * A formula, e.g. `~ .x + .y`. You must use `.x` to refer to the current
+#'   * A formula, e.g. `~ .x + .y`. Use `.x` to refer to the current
 #'     element of `x` and `.y` to refer to the current element of `y`.
-#'     No longer recommended.
+#'     Only recommended if you require backward compatibility with older versions of R.
 #'
 #'   `r lifecycle::badge("experimental")`
 #'

--- a/R/pmap.R
+++ b/R/pmap.R
@@ -20,7 +20,7 @@
 #'   * A named function.
 #'   * An anonymous function, e.g. `\(x, y, z) x + y / z` or
 #'     `function(x, y, z) x + y / z`
-#'   * A formula, e.g. `~ ..1 + ..2 / ..3`. No longer recommended.
+#'   * A formula, e.g. `~ ..1 + ..2 / ..3`. Only recommended if you require backward compatibility with older versions of R.
 #'
 #'   `r lifecycle::badge("experimental")`
 #'

--- a/README.Rmd
+++ b/README.Rmd
@@ -65,8 +65,8 @@ This example illustrates some of the advantages of purrr functions over the equi
   throw an error.
   
 * All `map()` functions accept functions (named, anonymous, and lambda), 
-  character vector (used to extract components by name), or numeric vectors 
-  (used to extract by position).
+   character vectors (used to extract components by name), or numeric vectors 
+  (used to extract by position). Note the use of the shorthand notation for anonymous functions (e.g. `\(x) x + 1` which is equivalent to `function(x) x + 1`) introduced in R 4.1. Formula notation for anonymous functions (e.g. `~ .x + 1`) may also be used, but this is only recommended if you require backward compatibility with older versions of R.
 
 There are two less obvious advantages:
 

--- a/vignettes/base.Rmd
+++ b/vignettes/base.Rmd
@@ -162,7 +162,7 @@ sds <- 1:4
     str(samples)
     ```
 
-    Alternatively, we could use `Map()` which doesn't simply, but also doesn't take any constant arguments, so we need to use an anonymous function:
+    Alternatively, we could use `Map()` which doesn't simplify, but also doesn't take any constant arguments, so we need to use an anonymous function:
 
     ```{r}
     samples <- Map(function(...) rnorm(..., n = 5), mean = means, sd = sds)

--- a/vignettes/other-langs.Rmd
+++ b/vignettes/other-langs.Rmd
@@ -29,7 +29,7 @@ However, the goal of purrr is not to try and simulate a purer functional program
 * Instead of currying, we use `...` to pass in extra arguments.
 
 * Before R 4.1, anonymous functions were verbose, so we provide two convenient shorthands.
-  For unary functions, `~ .x + 1` is equivalent to `function(.x) .x + 1`.
+  For unary functions, `~ .x + 1` is equivalent to `function(.x) .x + 1`. This formula notation is only recommended if you require backward compatibility with older versions of R. We suggest using the shorthand notation added in R 4.1 where `\(x) x + 1` is equivalent to `function(x) x + 1`. 
 
 * R is weakly typed, so we need `map` variants that describe the output type 
   (like `map_int()`, `map_dbl()`, etc) because we don't know the return type of `.f`.


### PR DESCRIPTION
addresses #1205 

Examples, vignettes, and readme no longer have mentions to formulas except for a more consistent message explaining that these may be used but only for backward compatibility with older versions of R.
* also fixed a typo or two

part of Tidyverse Dev Day 2025, ATL