### PR TITLE
do not use rerun in example (deprecated)

### DIFF
--- a/R/keep.R
+++ b/R/keep.R
@@ -33,7 +33,7 @@
 #'
 #' # Using a string instead of a function will select all list elements
 #' # where that subelement is TRUE
-#' x <- rerun(5, a = rbernoulli(1), b = sample(10))
+#' x <- map(1:5, ~ list(a = rbernoulli(1), b = sample(10)))
 #' x
 #' x |> keep("a")
 #' x |> discard("a")

--- a/man/keep.Rd
+++ b/man/keep.Rd
@@ -49,7 +49,7 @@ rep(10, 10) |>
 
 # Using a string instead of a function will select all list elements
 # where that subelement is TRUE
-x <- rerun(5, a = rbernoulli(1), b = sample(10))
+x <- map(1:5, ~ list(a = rbernoulli(1), b = sample(10)))
 x
 x |> keep("a")
 x |> discard("a")


### PR DESCRIPTION
I noted this example was using a deprecated function, it would be good to avoid warnings in the examples and use `map` like suggested