### PR TITLE
Pass user_env to vctrs compat helpers in pmap()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # purrr (development version)
 
+* `pmap()` now passes `user_env` to the vctrs compatibility helpers, fixing a spurious "argument `user_env` is missing" error when given a pairlist.
+
 # purrr 1.2.2
 
 * Fixes for CRAN checks (@ErdaradunGaztea, #1256).

--- a/R/pmap.R
+++ b/R/pmap.R
@@ -137,8 +137,8 @@ pmap_ <- function(
     caller_env = .purrr_error_call
   )
 
-  .l <- vctrs_list_compat(.l, error_call = .purrr_error_call)
-  .l <- map(.l, vctrs_vec_compat)
+  .l <- vctrs_list_compat(.l, .purrr_user_env, error_call = .purrr_error_call)
+  .l <- map(.l, vctrs_vec_compat, user_env = .purrr_user_env)
 
   n <- vec_size_common(!!!.l, .arg = ".l", .call = .purrr_error_call)
   .l <- vec_recycle_common(

--- a/tests/testthat/test-pmap.R
+++ b/tests/testthat/test-pmap.R
@@ -113,3 +113,8 @@ test_that("don't evaluate symbolic objects (#428)", {
   pmap(list(exprs(1 + 2)), ~ expect_identical(.x, quote(1 + 2)))
   pwalk(list(exprs(1 + 2)), ~ expect_identical(.x, quote(1 + 2)))
 })
+
+test_that("pairlists are deprecated but work", {
+  local_options(lifecycle_verbosity = "quiet")
+  expect_equal(pmap(pairlist(1:2, 3:4), sum), list(4, 6))
+})


### PR DESCRIPTION
# Pass user_env to vctrs compat helpers in pmap()

`pmap_()` in R/pmap.R calls `vctrs_list_compat()` and `vctrs_vec_compat()` without their `user_env` argument. Both helpers live in R/utils.R and take `user_env` as a required formal; they hand it to `lifecycle::deprecate_soft()` when the input is a pairlist. So any pairlist passed to `pmap()` fails before the deprecation warning can fire:

```r
pmap(pairlist(1:2, 3:4), sum)
#> Error: argument "user_env" is missing, with no default
```

Found during my most recent [ry](https://github.com/sims1253/ry) audit.
